### PR TITLE
Updating the --version response to display the current working version instead of the one installed on the machine.

### DIFF
--- a/depscan/__init__.py
+++ b/depscan/__init__.py
@@ -1,0 +1,3 @@
+__VERSION__ = "4.2.7"
+__LICENSE__ = "MIT"
+__TITLE__ = "dep-scan"

--- a/depscan/cli.py
+++ b/depscan/cli.py
@@ -17,6 +17,7 @@ from vdb.lib.nvd import NvdSource
 from vdb.lib.osv import OSVSource
 from vdb.lib.utils import parse_purl
 
+from depscan import __VERSION__
 from depscan.lib import privado, utils
 from depscan.lib.analysis import (
     PrepareVexOptions,
@@ -32,7 +33,6 @@ from depscan.lib.bom import create_bom, get_pkg_by_type, get_pkg_list, submit_bo
 from depscan.lib.config import UNIVERSAL_SCAN_TYPE, license_data_dir, spdx_license_list
 from depscan.lib.license import build_license_data, bulk_lookup
 from depscan.lib.logger import LOG, console
-from depscan.lib.utils import get_version
 
 try:
     os.environ["PYTHONIOENCODING"] = "utf-8"
@@ -245,7 +245,7 @@ def build_args():
         "--version",
         help="Display the version",
         action="version",
-        version="%(prog)s " + get_version(),
+        version=f"%(prog)s {__VERSION__}",
     )
     return parser.parse_args()
 
@@ -402,7 +402,7 @@ def summarise(
                     # Update the tools section
                     if isinstance(tools, dict):
                         components = tools.get("components", [])
-                        ds_version = get_version()
+                        ds_version = __VERSION__
                         ds_purl = f"pkg:pypi/owasp-depscan@{ds_version}"
                         components.append(
                             {

--- a/depscan/lib/utils.py
+++ b/depscan/lib/utils.py
@@ -1,6 +1,5 @@
 import ast
 import os
-import pkg_resources
 import re
 from collections import defaultdict
 
@@ -367,10 +366,3 @@ def get_all_imports(src_dir):
                         import_list.add(pkg)
                         import_list.add(pkg.lower().replace("py", ""))
     return import_list
-
-
-def get_version():
-    """
-    Returns the version of depscan
-    """
-    return pkg_resources.get_distribution("owasp-depscan").version


### PR DESCRIPTION
Currently, the `--version` flag returns the version of owasp-dep-check that is installed on the machine (by returning `pkg_resources.get_distribution("owasp-depscan").version`). However, this might be inconsistent with the latest version that depscan's repo is on. For example, the dep-scan executable might be on an older version while the repo is on a newer version. Upon executing the `--version` flag, the older version will be returned.

This PR adds a __VERSION__ string to return the actual version that the repo (or depscan executable) is on. While this could cause a slight overhead to change it during release cuts, it will eliminate the inconsistency of versions. 