### PR TITLE
Using oras-py to download the vulnerability data.

### DIFF
--- a/.github/workflows/dockertests.yml
+++ b/.github/workflows/dockertests.yml
@@ -37,13 +37,13 @@ jobs:
         mkdir -p containertests
         rm -rf $VDB_HOME && mkdir -p $VDB_HOME
         pip install -r contrib/requirements.txt
-        # python3 depscan/cli.py --cache-os --no-error --src ghcr.io/owasp-dep-scan/dep-scan -o containertests/depscan-scan.json -t docker
+        # python3 depscan/cli.py --cache --no-error --src ghcr.io/owasp-dep-scan/dep-scan -o containertests/depscan-scan.json -t docker
         # python contrib/vex-validate.py --json containertests/sbom-scan-docker.vex.json
         # rm -rf $VDB_HOME && mkdir -p $VDB_HOME
-        python3 depscan/cli.py --cache-os --no-error --src shiftleft/scan-slim -o containertests/depscan-slim.json -t docker,license --no-vuln-table
+        python3 depscan/cli.py --cache --no-error --src shiftleft/scan-slim -o containertests/depscan-slim.json -t docker,license --no-vuln-table
         python contrib/vex-validate.py --json containertests/sbom-slim-docker.vex.json
         rm -rf $VDB_HOME && mkdir -p $VDB_HOME
-        python3 depscan/cli.py --cache-os --no-error --src redmine@sha256:a5c5f8a64a0d9a436a0a6941bc3fb156be0c89996add834fe33b66ebeed2439e -o containertests/depscan-redmine.json -t docker --no-vuln-table
+        python3 depscan/cli.py --cache --no-error --src redmine@sha256:a5c5f8a64a0d9a436a0a6941bc3fb156be0c89996add834fe33b66ebeed2439e -o containertests/depscan-redmine.json -t docker --no-vuln-table
         python contrib/vex-validate.py --json containertests/sbom-redmine-docker.vex.json
         ls -ltr containertests
       env:

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ OWASP dep-scan is a fully open-source security audit tool based on known vulnera
 - NVD
 - GitHub
 - NPM
-- Linux [vuln-list](https://github.com/appthreat/vuln-list) (Use `--cache-os`)
+- Linux [vuln-list](https://github.com/appthreat/vuln-list)
 
 ### Linux distros
 
@@ -40,7 +40,7 @@ OWASP dep-scan is a fully open-source security audit tool based on known vulnera
 - Chainguard
 - Wolfi OS
 
-Application vulnerabilities would be reported for all Linux distros and Windows. To download the full vulnerability database suitable for scanning OS, invoke dep-scan with `--cache-os` for the first time. dep-scan would also download the appropriate database based on project type automatically.
+Application vulnerabilities would be reported for all Linux distros and Windows. To download the full vulnerability database suitable for scanning OS, invoke dep-scan with `--cache` for the first time. dep-scan would also download the appropriate database based on project type automatically.
 
 ## Usage
 
@@ -98,13 +98,6 @@ In server mode, use `/cache` endpoint to cache the vulnerability database.
 curl http://0.0.0.0:7070/cache
 ```
 
-Cache all vulnerabilities including os.
-
-```bash
-# This would take over 5 minutes
-curl http://0.0.0.0:7070/cache?os=true
-```
-
 Use the `/scan` endpoint to perform scans.
 
 ```bash
@@ -145,12 +138,11 @@ depscan --src $PWD --reports-dir $PWD/reports
 Full list of options are below:
 
 ```bash
-usage: depscan [-h] [--no-banner] [--cache] [--cache-os] [--sync] [--suggest] [--risk-audit] [--private-ns PRIVATE_NS] [-t PROJECT_TYPE] [--bom BOM] -i SRC_DIR
+usage: depscan [-h] [--no-banner] [--cache] [--sync] [--suggest] [--risk-audit] [--private-ns PRIVATE_NS] [-t PROJECT_TYPE] [--bom BOM] -i SRC_DIR
               [--reports-dir REPORTS_DIR] [--no-error] [--deep]
   -h, --help            show this help message and exit
   --no-banner           Do not display banner
   --cache               Cache vulnerability information in platform specific user_data_dir
-  --cache-os            Cache OS vulnerability information in platform specific user_data_dir
   --sync                Sync to receive the latest vulnerability data. Should have invoked cache first.
   --risk-audit          Perform package risk audit (slow operation). Npm only.
   --private-ns PRIVATE_NS

--- a/depscan/lib/config.py
+++ b/depscan/lib/config.py
@@ -296,6 +296,8 @@ npm_app_info = {"name": "appthreat-depscan", "version": "1.0.0"}
 
 pypi_server = "https://pypi.org/pypi"
 
+vdb_database_url = "ghcr.io/appthreat/vdb:v5"
+
 # Package risk scoring using a simple weighted formula with no backing
 # research All parameters and their max value and weight can be overridden
 # using environment variables

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ authors = [
 dependencies = [
     "appthreat-vulnerability-db>=5.4.2",
     "defusedxml",
+    "oras",
     "PyYAML",
     "rich",
     "quart",


### PR DESCRIPTION
The current scheme uses the [vdb library](https://pypi.org/project/appthreat-vulnerability-db/) to sequentially download the vulnerability data from NVD, OSV, GitHub, etc. advisories. However, there exists a [vdb image](https://github.com/AppThreat/vdb/pkgs/container/vdb) that has the data from all these advisories baked into it. Hence, instead of sequentially downloading data, the image artifacts can be downloaded.

Note:

* This commit removes the "--cache-os" argument as it is no longer needed. The OS vulnerability data exists in the vdb image.
* This commit does NOT remove the "--sync" argument as one might want to just sync (get the latest vulnerability data) instead of downloading everything.