### PR TITLE
Refactoring the code for detecting the project type

### DIFF
--- a/depscan/lib/config.py
+++ b/depscan/lib/config.py
@@ -430,3 +430,25 @@ max_request_failures = get_int_from_env("max_request_failures", 5)
 
 # Universal scan
 UNIVERSAL_SCAN_TYPE = "universal"
+
+PROJECT_TYPES = {
+    "docker": ["Dockerfile", "docker-compose.yml", "docker-compose.yaml", ".tar", ".tar.gz", ".tgz", "docker.io", "quay.io", ":latest", "@sha256"],
+    "python": [".py", "requirements.txt", "Pipfile", "poetry.lock", "Pipfile.lock", "conda.yml", "pyproject.toml"],
+    "java": ["pom.xml", ".gradle", ".gradle.kts"],
+    "kotlin": ["build.gradle.kts", "build.kts"],
+    "scala": ["build.sbt"],
+    "nodejs": ["package.json", "yarn.lock", "rush.json"],
+    "go": ["go.sum", "Gopkg.lock"],
+    "rust": ["Cargo.lock"],
+    "php": ["composer.json"],
+    "dotnet": [".csproj"],
+    "ruby": ["Gemfile", "Gemfile.lock"],
+    "clojure": ["deps.edn", "project.clj"],
+    "cpp": ["conan.lock", "conanfile.txt"],
+    "dart": ["pubspec.lock", "pubspec.yaml"],
+    "haskell": ["cabal.project.freeze"],
+    "elixir": ["mix.lock"],
+    "jar": [".jar"],
+    "jenkins": [".hpi"],
+    "yaml-manifest": [".yml", ".yaml"],
+}


### PR DESCRIPTION
Currently, the `detect_project_type` parameter `src_dir` is a bit ambiguous. While checking for "docker" project type, the parameter is assumed to be a file name (or a complete file path), but while checking for other project types, it is assumed to be a path to a directory (and not a file).

This PR attempts to fix this ambiguity as well as refactor the code a bit.