### PR TITLE
Expand, improve, consolidate dockertests

### DIFF
--- a/.github/workflows/dockertests.yml
+++ b/.github/workflows/dockertests.yml
@@ -13,8 +13,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ['3.8', '3.9', '3.10', '3.11']
+      fail-fast: false
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python
@@ -29,22 +30,34 @@ jobs:
         python3 -m pip install .[dev]
         npm install -g @cyclonedx/cdxgen
         mkdir -p repotests
+#    - name: VDB
+#      if: matrix.os != 'windows-latest'
+#      run: |
+#        rm -rf $VDB_HOME && mkdir -p $VDB_HOME
+#      env:
+#        VDB_HOME: "vdb_data"
+    - name: Run pytest tests
+      run: |
+        python3 -m pip install -r contrib/requirements.txt
+        python3 -m pytest test
+      env:
+        PYTHONPATH: "."
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        VDB_HOME: "vdb_data"
     - name: Test container images
       run: |
-        mkdir -p containertests
-        rm -rf $VDB_HOME && mkdir -p $VDB_HOME
-        pip install -r contrib/requirements.txt
-        # python3 depscan/cli.py --no-banner --cache --no-error --src ghcr.io/owasp-dep-scan/dep-scan -o containertests/depscan-scan.json -t docker
-        python3 depscan/cli.py --no-banner --cache --no-error --src shiftleft/scan-slim -o containertests/depscan-slim.json -t docker,license --no-vuln-table
-        python3 depscan/cli.py --no-banner --no-error --src redmine@sha256:a5c5f8a64a0d9a436a0a6941bc3fb156be0c89996add834fe33b66ebeed2439e -o containertests/depscan-redmine.json -t docker --no-vuln-table
+        mkdir -p containertests_${{ matrix.os }}_python${{ matrix.python-version }}
+        # python3 depscan/cli.py --no-banner --cache --no-error --src ghcr.io/owasp-dep-scan/dep-scan -o containertests_${{ matrix.os }}_python${{ matrix.python-version }}/depscan-scan.json -t docker
+        python3 depscan/cli.py --no-banner --cache --no-error --src shiftleft/scan-slim -o containertests_${{ matrix.os }}_python${{ matrix.python-version }}/depscan-slim.json -t docker,license --no-vuln-table
+        python3 depscan/cli.py --no-banner --no-error --src redmine@sha256:a5c5f8a64a0d9a436a0a6941bc3fb156be0c89996add834fe33b66ebeed2439e -o containertests_${{ matrix.os }}_python${{ matrix.python-version }}/depscan-redmine.json -t docker --no-vuln-table
       env:
         PYTHONPATH: "."
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         VDB_HOME: "vdb_data"
     - uses: actions/upload-artifact@v1
       with:
-        name: containertests
-        path: containertests
+        name: containertests_${{ matrix.os }}_python${{ matrix.python-version }}
+        path: containertests_${{ matrix.os }}_python${{ matrix.python-version }}
   version_tests2:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -65,38 +78,6 @@ jobs:
         python3 -m pip install .[dev]
         npm install -g @cyclonedx/cdxgen
         mkdir -p repotests
-    - name: Test container images
-      run: |
-        mkdir -p containertests
-        pip install -r contrib/requirements.txt
-        python3 depscan/cli.py --no-banner --no-error --src rocket.chat@sha256:379f7afa0e67497c363ac9a9b3e7e6a6d31deee228233307c987e4a0c68b28e6 -o containertests/depscan-rocket.json --no-vuln-table
-        python3 depscan/cli.py --no-banner --no-error --src ./test/data/bom-yaml-manifest.json -o containertests/depscan-yaml.json --no-vuln-table
-      env:
-        PYTHONPATH: "."
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - uses: actions/upload-artifact@v1
-      with:
-        name: containertests2
-        path: containertests
-  ms_tests:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ['3.11']
-    steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Display Python version
-      run: python -c "import sys; print(sys.version)"
-    - name: Install dependencies
-      run: |
-        python3 -m pip install --upgrade pip
-        python3 -m pip install .[dev]
-        sudo npm install -g @cyclonedx/cdxgen
-        mkdir -p repotests
     - uses: actions/checkout@v4
       with:
         repository: 'GoogleCloudPlatform/microservices-demo'
@@ -107,10 +88,17 @@ jobs:
         path: 'repotests/NodeGoat'
     - name: Test container images
       run: |
-        mkdir -p containertests
-        pip install -r contrib/requirements.txt
-        python3 depscan/cli.py --no-error --src repotests/microservices-demo -o containertests/depscan-msd.json
-        python3 depscan/cli.py --no-error --src repotests/NodeGoat --reports-dir containertests/ng-reports
+        mkdir -p containertests_${{ matrix.os }}
+        python3 -m pip install -r contrib/requirements.txt
+        python3 depscan/cli.py --no-banner --no-error --src rocket.chat@sha256:379f7afa0e67497c363ac9a9b3e7e6a6d31deee228233307c987e4a0c68b28e6 -o containertests_${{ matrix.os }}/depscan-rocket.json --no-vuln-table
+        python3 depscan/cli.py --no-banner --no-error --src ./test/data/bom-yaml-manifest.json -o containertests_${{ matrix.os }}/depscan-yaml.json --no-vuln-table
+        python3 depscan/cli.py --no-banner --no-error --src repotests/microservices-demo -o containertests_${{ matrix.os }}/depscan-msd.json
+        python3 depscan/cli.py --no-banner --no-error --src repotests/NodeGoat --reports-dir containertests_${{ matrix.os }}/ng-reports
       env:
         PYTHONPATH: "."
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PYTHONUTF8: 1
+    - uses: actions/upload-artifact@v1
+      with:
+        name: containertests_${{ matrix.os }}
+        path: containertests_${{ matrix.os }}


### PR DESCRIPTION
- Expands matrix to run everything on all OSes, 
- Adds running pytest tests for all os x python-version
- Addresses codec issue in ms_test on Windows, 
- Combines ms_test and version_tests2 for efficiency (leaves version_tests separate due to multiple python versions in matrix).
- Adds improved artifacts names so that artifacts aren't written over due to using same artifact name for all runs in matrix

Successful [run](https://github.com/cerrussell/dep-scan/actions/runs/6366805280).

We may want to clarify what is being tested by renaming this workflow and certain steps in the future since Docker and containers don't appear to be involved.

Closes #135 