### PR TITLE
Adds 3.12 tests

### DIFF
--- a/.github/workflows/dockertests.yml
+++ b/.github/workflows/dockertests.yml
@@ -26,7 +26,7 @@ jobs:
       run: python -c "import sys; print(sys.version)"
     - name: Install dependencies
       run: |
-        python3 -m pip install --upgrade pip
+        python3 -m pip install --upgrade pip setuptools
         python3 -m pip install .[dev]
         npm install -g @cyclonedx/cdxgen
         mkdir -p repotests

--- a/.github/workflows/dockertests.yml
+++ b/.github/workflows/dockertests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
       fail-fast: false
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/gobintests.yml
+++ b/.github/workflows/gobintests.yml
@@ -23,7 +23,7 @@ jobs:
       run: python -c "import sys; print(sys.version)"
     - name: Install dependencies
       run: |
-        python3 -m pip install --upgrade pip
+        python3 -m pip install --upgrade pip setuptools
         python3 -m pip install .[dev]
         sudo npm install -g @cyclonedx/cdxgen
     - name: Test go binaries

--- a/.github/workflows/gobintests.yml
+++ b/.github/workflows/gobintests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -22,7 +22,7 @@ jobs:
       run: python -c "import sys; print(sys.version)"
     - name: Install dependencies
       run: |
-        python3 -m pip install --upgrade pip
+        python3 -m pip install --upgrade pip setuptools
         python3 -m pip install ".[dev]"
     - name: Lint with flake8
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Security",
     "Topic :: Utilities",
 ]


### PR DESCRIPTION
- [ ] setuptools is [no longer installed](https://docs.python.org/3.12/whatsnew/3.12.html#ensurepip) in venv in Python 3.12. Is there a different way to rewrite the get_version method to avoid this dependency?

https://github.com/owasp-dep-scan/dep-scan/blob/master/depscan/lib/utils.py#L376