### PR TITLE
Reuse pkg_vulnerabilities list instead of results list for CSAF generation

### DIFF
--- a/depscan/cli.py
+++ b/depscan/cli.py
@@ -1105,8 +1105,6 @@ def main():
                 src_dir,
                 reports_dir,
                 vdr_file,
-                direct_purls=direct_purls,
-                reached_purls=reached_purls,
             )
     console.save_html(
         html_file,

--- a/depscan/cli.py
+++ b/depscan/cli.py
@@ -1101,10 +1101,10 @@ def main():
         # CSAF VEX export
         if args.csaf:
             export_csaf(
-                results,
+                pkg_vulnerabilities,
                 src_dir,
                 reports_dir,
-                vdr_file,
+                bom_file,
             )
     console.save_html(
         html_file,

--- a/depscan/lib/analysis.py
+++ b/depscan/lib/analysis.py
@@ -141,9 +141,8 @@ def get_pkg_display(tree_pkg, current_pkg, extra_text=None):
                 if purl_obj:
                     version_used = purl_obj.get("version")
                     if version_used:
-                        full_pkg_display = (
-                            f"""{purl_obj.get("name")}@{version_used}"""
-                        )
+                        full_pkg_display = (f"{purl_obj.get("name")}"
+                                            f"@{version_used}")
         except Exception:
             pass
     if extra_text and highlightable:
@@ -470,8 +469,7 @@ def prepare_vdr(options: PrepareVdrOptions):
         if clinks.get("poc") or clinks.get("Bug Bounty"):
             if reached_purls.get(purl):
                 insights.append(
-                    "[bright_red]:exclamation_mark: Reachable and "
-                    "Exploitable[/bright_red]"
+                    "[bright_red]:exclamation_mark: Reachable and Exploitable[/bright_red]"
                 )
                 plain_insights.append("Reachable and Exploitable")
                 has_reachable_poc_count += 1
@@ -479,8 +477,7 @@ def prepare_vdr(options: PrepareVdrOptions):
                 pkg_requires_attn = True
             elif direct_purls.get(purl):
                 insights.append(
-                    "[yellow]:notebook_with_decorative_cover: Bug Bounty "
-                    "target[/yellow]"
+                    "[yellow]:notebook_with_decorative_cover: Bug Bounty target[/yellow]"
                 )
                 plain_insights.append("Bug Bounty target")
             else:
@@ -501,8 +498,7 @@ def prepare_vdr(options: PrepareVdrOptions):
         if clinks.get("exploit"):
             if reached_purls.get(purl) or direct_purls.get(purl):
                 insights.append(
-                    "[bright_red]:exclamation_mark: Reachable and "
-                    "Exploitable[/bright_red]"
+                    "[bright_red]:exclamation_mark: Reachable and Exploitable[/bright_red]"
                 )
                 plain_insights.append("Reachable and Exploitable")
                 has_reachable_exploit_count += 1
@@ -538,10 +534,8 @@ def prepare_vdr(options: PrepareVdrOptions):
                 p_rich_tree,
                 "\n".join(insights),
                 fixed_location,
-                f"{"[bright_red]" if pkg_severity == "CRITICAL" else ""}"
-                f"{vuln_occ_dict.get("severity")}",
-                f"{"[bright_red]" if pkg_severity == "CRITICAL" else ""}"
-                f"{vuln_occ_dict.get("cvss_score")}",
+                f"""{"[bright_red]" if pkg_severity == "CRITICAL" else ""}{vuln_occ_dict.get("severity")}""",
+                f"""{"[bright_red]" if pkg_severity == "CRITICAL" else ""}{vuln_occ_dict.get("cvss_score")}""",
             )
         if purl:
             source = {}
@@ -555,10 +549,7 @@ def prepare_vdr(options: PrepareVdrOptions):
                     "name": "GitHub",
                     "url": f"https://github.com/advisories/{vid}",
                 }
-            versions = [{
-                "version": version_used,
-                "status": "affected"
-            }]
+            versions = [{"version": version_used, "status": "affected"}]
             recommendation = ""
             if fixed_location:
                 versions.append(
@@ -630,8 +621,8 @@ def prepare_vdr(options: PrepareVdrOptions):
         psection = Markdown(
             """## Next Steps
 
-Below are the vulnerabilities prioritized by depscan. Follow your team's
-remediation workflow to mitigate these findings."""
+Below are the vulnerabilities prioritized by depscan. Follow your team's remediation workflow to mitigate these findings.
+        """
         )
         console.print(psection)
         utable = Table(
@@ -665,8 +656,8 @@ remediation workflow to mitigate these findings."""
                 rmessage = (
                     f":point_right: [magenta]{has_reachable_exploit_count}"
                     f"[/magenta] out of {len(options.results)} vulnerabilities "
-                    f"have [dark magenta]reachable[/dark magenta] exploits "
-                    f"and requires your [magenta]immediate[/magenta] attention."
+                    f"have [dark magenta]reachable[/dark magenta] exploits and requires your ["
+                    f"magenta]immediate[/magenta] attention."
                 )
             else:
                 rmessage = (
@@ -702,13 +693,9 @@ remediation workflow to mitigate these findings."""
                         f"for updates."
                     )
                 if has_redhat_packages:
-                    rmessage += """\nNOTE: Vulnerabilities in RedHat packages
-                    with status "out of support" or "won't fix" are excluded
-                    from this result."""
+                    rmessage += """\nNOTE: Vulnerabilities in RedHat packages with status "out of support" or "won't fix" are excluded from this result."""
                 if has_ubuntu_packages:
-                    rmessage += """\nNOTE: Vulnerabilities in Ubuntu packages
-                    with status "DNE" or "needs-triaging" are excluded from
-                    this result."""
+                    rmessage += """\nNOTE: Vulnerabilities in Ubuntu packages with status "DNE" or "needs-triaging" are excluded from this result."""
             console.print(
                 Panel(
                     rmessage,
@@ -719,10 +706,8 @@ remediation workflow to mitigate these findings."""
         elif pkg_attention_count:
             if has_reachable_exploit_count:
                 rmessage = (
-                    f":point_right: Prioritize the [magenta]"
-                    f"{has_reachable_exploit_count}[/magenta] [bold magenta]"
-                    f"reachable[/bold magenta] vulnerabilities with known "
-                    f"exploits."
+                    f":point_right: Prioritize the [magenta]{has_reachable_exploit_count}"
+                    f"[/magenta] [bold magenta]reachable[/bold magenta] vulnerabilities with known exploits."
                 )
             elif has_exploit_count:
                 rmessage = (
@@ -763,9 +748,9 @@ remediation workflow to mitigate these findings."""
         elif critical_count:
             console.print(
                 Panel(
-                    f":white_medium_small_square: Prioritize the [magenta]"
-                    f"{critical_count}[/magenta] critical vulnerabilities "
-                    f"confirmed by the vendor.",
+                    f":white_medium_small_square: Prioritize the [magenta]{critical_count}"
+                    f"[/magenta] critical vulnerabilities confirmed by the "
+                    f"vendor.",
                     title="Recommendation",
                     expand=False,
                 )
@@ -773,19 +758,20 @@ remediation workflow to mitigate these findings."""
         else:
             if has_os_packages:
                 rmessage = (
-                    ":white_medium_small_square: Prioritize any "
-                    "vulnerabilities in libraries such as glibc, openssl, "
-                    "or libcurl.\nAdditionally, prioritize the "
-                    "vulnerabilities in packages that provide executable "
-                    "binaries when there is a Remote Code Execution or File "
-                    "Write vulnerability in the containerized application or "
-                    "service."
+                    ":white_medium_small_square: Prioritize any vulnerabilities in libraries such "
+                    "as glibc, openssl, or libcurl.\nAdditionally, "
+                    "prioritize the vulnerabilities in packages that "
+                    "provide executable binaries when there is a "
+                    "Remote Code Execution or File Write "
+                    "vulnerability in the containerized application "
+                    "or service."
                 )
                 rmessage += (
-                    "\nVulnerabilities in Linux Kernel packages can be "
-                    "usually ignored in containerized environments as long as "
-                    "the vulnerability doesn't lead to any 'container-escape' "
-                    "type vulnerabilities."
+                    "\nVulnerabilities in Linux Kernel packages can "
+                    "be usually ignored in containerized "
+                    "environments as long as the vulnerability "
+                    "doesn't lead to any 'container-escape' type "
+                    "vulnerabilities."
                 )
                 if has_redhat_packages:
                     rmessage += """\nNOTE: Vulnerabilities in RedHat packages
@@ -797,17 +783,11 @@ remediation workflow to mitigate these findings."""
                     this result."""
                 console.print(Panel(rmessage, title="Recommendation"))
             else:
-                rmessage = (":white_check_mark: No package requires immediate "
-                            "attention.")
+                rmessage = ":white_check_mark: No package requires immediate attention."
                 if reached_purls:
-                    rmessage = (":white_check_mark: No package requires "
-                                "immediate attention since the major "
-                                "vulnerabilities are not reachable.")
+                    rmessage = ":white_check_mark: No package requires immediate attention since the major vulnerabilities are not reachable."
                 elif direct_purls:
-                    rmessage = (":white_check_mark: No package requires "
-                                "immediate attention since the major "
-                                "vulnerabilities are found only in dev "
-                                "packages and indirect dependencies.")
+                    rmessage = ":white_check_mark: No package requires immediate attention since the major vulnerabilities are found only in dev packages and indirect dependencies."
                 console.print(
                     Panel(
                         rmessage,
@@ -818,9 +798,8 @@ remediation workflow to mitigate these findings."""
     elif critical_count:
         console.print(
             Panel(
-                f":white_medium_small_square: Prioritize the [magenta"
-                f"]{critical_count}[/magenta] critical vulnerabilities "
-                f"confirmed by the vendor.",
+                f":white_medium_small_square: Prioritize the [magenta]{critical_count}"
+                f"[/magenta] critical vulnerabilities confirmed by the vendor.",
                 title="Recommendation",
                 expand=False,
             )
@@ -844,9 +823,8 @@ remediation workflow to mitigate these findings."""
         rsection = Markdown(
             """## Proactive Measures
 
-Below are the top reachable packages identified by depscan. Setup alerts and
-notifications to actively monitor these packages for new vulnerabilities and
-exploits."""
+Below are the top reachable packages identified by depscan. Setup alerts and notifications to actively monitor these packages for new vulnerabilities and exploits.
+        """
         )
         console.print(rsection)
         rtable = Table(
@@ -1033,12 +1011,11 @@ def jsonl_report(
                     if purl_obj:
                         version_used = purl_obj.get("version")
                         if purl_obj.get("namespace"):
-                            full_pkg = (f"{purl_obj.get("namespace")}"
-                                        f"{purl_obj.get("name")}@"
-                                        f"{purl_obj.get("version")}")
+                            full_pkg = f"""{purl_obj.get("namespace")}/
+                            {purl_obj.get("name")}@{purl_obj.get("version")}"""
                         else:
-                            full_pkg = (f"{purl_obj.get('name')}"
-                                        f"@{purl_obj.get('version')}")
+                            full_pkg = f"""{purl_obj.get("name")}@{purl_obj
+                                .get("version")}"""
                 except Exception:
                     pass
             if ids_seen.get(vid + purl):
@@ -1046,9 +1023,7 @@ def jsonl_report(
             # On occasions, this could still result in duplicates if the
             # package exists with and without a purl
             ids_seen[vid + purl] = True
-            project_type_pkg = (f"{project_type}:"
-                                f"{package_issue["affected_location"]
-                                    .get("package")}")
+            project_type_pkg = f"""{project_type}:{package_issue["affected_location"].get("package")}"""
             fixed_location = best_fixed_location(
                 sug_version_dict.get(purl),
                 package_issue["fixed_location"],
@@ -1147,7 +1122,7 @@ def analyse_pkg_risks(
             risk_metrics.get("risk_score") > config.pkg_max_risk_score
             or risk_metrics.get("pkg_private_on_public_registry_risk")
         ):
-            risk_score = f"{round(risk_metrics.get("risk_score"), 2)}"
+            risk_score = f"""{round(risk_metrics.get("risk_score"), 2)}"""
             data = [
                 pkg,
                 package_usage,

--- a/depscan/lib/analysis.py
+++ b/depscan/lib/analysis.py
@@ -141,8 +141,9 @@ def get_pkg_display(tree_pkg, current_pkg, extra_text=None):
                 if purl_obj:
                     version_used = purl_obj.get("version")
                     if version_used:
-                        full_pkg_display = (f"{purl_obj.get("name")}"
-                                            f"@{version_used}")
+                        full_pkg_display = (
+                            f"""{purl_obj.get("name")}@{version_used}"""
+                        )
         except Exception:
             pass
     if extra_text and highlightable:
@@ -894,14 +895,14 @@ def cvss_to_vdr_rating(vuln_occ_dict):
         "score": cvss_score,
         "severity": pkg_severity,
     }]
-    method = "CVSSv31"
+    method = "31"
     if vuln_occ_dict.get("cvss_v3") and (
             vector_string := vuln_occ_dict["cvss_v3"].get("vector_string")):
         ratings[0]["vector"] = vector_string
         with contextlib.suppress(CVSSError):
-            method = f"CVSSv{cvss.CVSS3(vector_string).as_json().get(
-                'version').replace('.', '').replace('0', '')}"
-    ratings[0]["method"] = method
+            method = cvss.CVSS3(vector_string).as_json().get('version')
+            method = method.replace('.', '').replace('0', '')
+    ratings[0]["method"] = f"CVSSv{method}"
 
     return ratings
 

--- a/depscan/lib/csaf.py
+++ b/depscan/lib/csaf.py
@@ -1613,8 +1613,9 @@ def export_csaf(pkg_vulnerabilities, src_dir, reports_dir, bom_file):
         reports_dir,
         f"csaf_v{new_results['document']['tracking']['version']}.json",
     )
+
     with open(outfile, "w", encoding="utf-8") as f:
-        json.dump(new_results, f, indent=4)
+        json.dump(new_results, f, indent=4, sort_keys=True)
     LOG.info("CSAF report written to %s", outfile)
     write_toml(toml_file_path, metadata)
 

--- a/depscan/lib/csaf.py
+++ b/depscan/lib/csaf.py
@@ -1,14 +1,13 @@
 import json
-import logging
 import os
 import re
+import sys
 from copy import deepcopy
 from datetime import datetime
 from json import JSONDecodeError
 
 import toml
 from vdb.lib import convert_time
-from vdb.lib.utils import version_compare
 
 from depscan.lib.logger import LOG
 from depscan.lib.utils import get_version
@@ -16,1070 +15,1027 @@ from depscan.lib.utils import get_version
 TIME_FMT = "%Y-%m-%dT%H:%M:%S"
 
 CWE_MAP = {
-    "CWE-5": "J2EE Misconfiguration: Data Transmission Without Encryption",
-    "CWE-6": "J2EE Misconfiguration: Insufficient Session-ID Length",
-    "CWE-7": "J2EE Misconfiguration: Missing Custom Error Page",
-    "CWE-8": "J2EE Misconfiguration: Entity Bean Declared Remote",
-    "CWE-9": "J2EE Misconfiguration: Weak Access Permissions for EJB Methods",
-    "CWE-11": "ASP.NET Misconfiguration: Creating Debug Binary",
-    "CWE-12": "ASP.NET Misconfiguration: Missing Custom Error Page",
-    "CWE-13": "ASP.NET Misconfiguration: Password in Configuration File",
-    "CWE-14": "Compiler Removal of Code to Clear Buffers",
-    "CWE-15": "External Control of System or Configuration Setting",
-    "CWE-20": "Improper Input Validation",
-    "CWE-22": "Improper Limitation of a Pathname to a Restricted Directory",
-    "CWE-23": "Relative Path Traversal",
-    "CWE-24": "Path Traversal",
-    "CWE-25": "Path Traversal",
-    "CWE-26": "Path Traversal",
-    "CWE-27": "Path Traversal",
-    "CWE-28": "Path Traversal",
-    "CWE-29": "Path Traversal",
-    "CWE-30": "Path Traversal",
-    "CWE-31": "Path Traversal",
-    "CWE-32": "Path Traversal",
-    "CWE-33": "Path Traversal",
-    "CWE-34": "Path Traversal",
-    "CWE-35": "Path Traversal",
-    "CWE-36": "Absolute Path Traversal",
-    "CWE-37": "Path Traversal",
-    "CWE-38": "Path Traversal",
-    "CWE-39": "Path Traversal",
-    "CWE-40": "Path Traversal",
-    "CWE-41": "Improper Resolution of Path Equivalence",
-    "CWE-42": "Path Equivalence",
-    "CWE-43": "Path Equivalence",
-    "CWE-44": "Path Equivalence",
-    "CWE-45": "Path Equivalence",
-    "CWE-46": "Path Equivalence",
-    "CWE-47": "Path Equivalence",
-    "CWE-48": "Path Equivalence",
-    "CWE-49": "Path Equivalence",
-    "CWE-50": "Path Equivalence",
-    "CWE-51": "Path Equivalence",
-    "CWE-52": "Path Equivalence",
-    "CWE-53": "Path Equivalence",
-    "CWE-54": "Path Equivalence",
-    "CWE-55": "Path Equivalence",
-    "CWE-56": "Path Equivalence",
-    "CWE-57": "Path Equivalence",
-    "CWE-58": "Path Equivalence",
-    "CWE-59": "Improper Link Resolution Before File Access",
-    "CWE-61": "UNIX Symbolic Link",
-    "CWE-62": "UNIX Hard Link",
-    "CWE-64": "Windows Shortcut Following",
-    "CWE-65": "Windows Hard Link",
-    "CWE-66": "Improper Handling of File Names that Identify Virtual Resources",
-    "CWE-67": "Improper Handling of Windows Device Names",
-    "CWE-69": "Improper Handling of Windows ::DATA Alternate Data Stream",
-    "CWE-71": "DEPRECATED: Apple .DS_Store",
-    "CWE-72": "Improper Handling of Apple HFS+ Alternate Data Stream Path",
-    "CWE-73": "External Control of File Name or Path",
-    "CWE-74": "Improper Neutralization of Special Elements in Output Used by "
-    "a Downstream Component",
-    "CWE-75": "Failure to Sanitize Special Elements into a Different Plane",
-    "CWE-76": "Improper Neutralization of Equivalent Special Elements",
-    "CWE-77": "Improper Neutralization of Special Elements used in a Command",
-    "CWE-78": "Improper Neutralization of Special Elements used in an OS "
-    "Command",
-    "CWE-79": "Improper Neutralization of Input During Web Page Generation",
-    "CWE-80": "Improper Neutralization of Script-Related HTML Tags in a Web "
-    "Page",
-    "CWE-81": "Improper Neutralization of Script in an Error Message Web Page",
-    "CWE-82": "Improper Neutralization of Script in Attributes of IMG Tags in "
-    "a Web Page",
-    "CWE-83": "Improper Neutralization of Script in Attributes in a Web Page",
-    "CWE-84": "Improper Neutralization of Encoded URI Schemes in a Web Page",
-    "CWE-85": "Doubled Character XSS Manipulations",
-    "CWE-86": "Improper Neutralization of Invalid Characters in Identifiers "
-    "in Web Pages",
-    "CWE-87": "Improper Neutralization of Alternate XSS Syntax",
-    "CWE-88": "Improper Neutralization of Argument Delimiters in a Command",
-    "CWE-89": "Improper Neutralization of Special Elements used in an SQL "
-    "Command",
-    "CWE-90": "Improper Neutralization of Special Elements used in an LDAP "
-    "Query",
-    "CWE-91": "XML Injection",
-    "CWE-92": "DEPRECATED: Improper Sanitization of Custom Special Characters",
-    "CWE-93": "Improper Neutralization of CRLF Sequences",
-    "CWE-94": "Improper Control of Generation of Code",
-    "CWE-95": "Improper Neutralization of Directives in Dynamically Evaluated "
-    "Code",
-    "CWE-96": "Improper Neutralization of Directives in Statically Saved Code",
-    "CWE-97": "Improper Neutralization of Server-Side Includes",
-    "CWE-98": "Improper Control of Filename for Include/Require Statement in "
-    "PHP Program",
-    "CWE-99": "Improper Control of Resource Identifiers",
-    "CWE-102": "Struts: Duplicate Validation Forms",
-    "CWE-103": "Struts: Incomplete validate",
-    "CWE-104": "Struts: Form Bean Does Not Extend Validation Class",
-    "CWE-105": "Struts: Form Field Without Validator",
-    "CWE-106": "Struts: Plug-in Framework not in Use",
-    "CWE-107": "Struts: Unused Validation Form",
-    "CWE-108": "Struts: Unvalidated Action Form",
-    "CWE-109": "Struts: Validator Turned Off",
-    "CWE-110": "Struts: Validator Without Form Field",
-    "CWE-111": "Direct Use of Unsafe JNI",
-    "CWE-112": "Missing XML Validation",
-    "CWE-113": "Improper Neutralization of CRLF Sequences in HTTP Headers",
-    "CWE-114": "Process Control",
-    "CWE-115": "Misinterpretation of Input",
-    "CWE-116": "Improper Encoding or Escaping of Output",
-    "CWE-117": "Improper Output Neutralization for Logs",
-    "CWE-118": "Incorrect Access of Indexable Resource",
-    "CWE-119": "Improper Restriction of Operations within the Bounds of a "
-    "Memory Buffer",
-    "CWE-120": "Buffer Copy without Checking Size of Input",
-    "CWE-121": "Stack-based Buffer Overflow",
-    "CWE-122": "Heap-based Buffer Overflow",
-    "CWE-123": "Write-what-where Condition",
-    "CWE-124": "Buffer Underwrite",
-    "CWE-125": "Out-of-bounds Read",
-    "CWE-126": "Buffer Over-read",
-    "CWE-127": "Buffer Under-read",
-    "CWE-128": "Wrap-around Error",
-    "CWE-129": "Improper Validation of Array Index",
-    "CWE-130": "Improper Handling of Length Parameter Inconsistency",
-    "CWE-131": "Incorrect Calculation of Buffer Size",
-    "CWE-132": "DEPRECATED: Miscalculated Null Termination",
-    "CWE-134": "Use of Externally-Controlled Format String",
-    "CWE-135": "Incorrect Calculation of Multi-Byte String Length",
-    "CWE-138": "Improper Neutralization of Special Elements",
-    "CWE-140": "Improper Neutralization of Delimiters",
-    "CWE-141": "Improper Neutralization of Parameter/Argument Delimiters",
-    "CWE-142": "Improper Neutralization of Value Delimiters",
-    "CWE-143": "Improper Neutralization of Record Delimiters",
-    "CWE-144": "Improper Neutralization of Line Delimiters",
-    "CWE-145": "Improper Neutralization of Section Delimiters",
-    "CWE-146": "Improper Neutralization of Expression/Command Delimiters",
-    "CWE-147": "Improper Neutralization of Input Terminators",
-    "CWE-148": "Improper Neutralization of Input Leaders",
-    "CWE-149": "Improper Neutralization of Quoting Syntax",
-    "CWE-150": "Improper Neutralization of Escape, Meta, or Control Sequences",
-    "CWE-151": "Improper Neutralization of Comment Delimiters",
-    "CWE-152": "Improper Neutralization of Macro Symbols",
-    "CWE-153": "Improper Neutralization of Substitution Characters",
-    "CWE-154": "Improper Neutralization of Variable Name Delimiters",
-    "CWE-155": "Improper Neutralization of Wildcards or Matching Symbols",
-    "CWE-156": "Improper Neutralization of Whitespace",
-    "CWE-157": "Failure to Sanitize Paired Delimiters",
-    "CWE-158": "Improper Neutralization of Null Byte or NUL Character",
-    "CWE-159": "Improper Handling of Invalid Use of Special Elements",
-    "CWE-160": "Improper Neutralization of Leading Special Elements",
-    "CWE-161": "Improper Neutralization of Multiple Leading Special Elements",
-    "CWE-162": "Improper Neutralization of Trailing Special Elements",
-    "CWE-163": "Improper Neutralization of Multiple Trailing Special Elements",
-    "CWE-164": "Improper Neutralization of Internal Special Elements",
-    "CWE-165": "Improper Neutralization of Multiple Internal Special Elements",
-    "CWE-166": "Improper Handling of Missing Special Element",
-    "CWE-167": "Improper Handling of Additional Special Element",
-    "CWE-168": "Improper Handling of Inconsistent Special Elements",
-    "CWE-170": "Improper Null Termination",
-    "CWE-172": "Encoding Error",
-    "CWE-173": "Improper Handling of Alternate Encoding",
-    "CWE-174": "Double Decoding of the Same Data",
-    "CWE-175": "Improper Handling of Mixed Encoding",
-    "CWE-176": "Improper Handling of Unicode Encoding",
-    "CWE-177": "Improper Handling of URL Encoding",
-    "CWE-178": "Improper Handling of Case Sensitivity",
-    "CWE-179": "Incorrect Behavior Order: Early Validation",
-    "CWE-180": "Incorrect Behavior Order: Validate Before Canonicalize",
-    "CWE-181": "Incorrect Behavior Order: Validate Before Filter",
-    "CWE-182": "Collapse of Data into Unsafe Value",
-    "CWE-183": "Permissive List of Allowed Inputs",
-    "CWE-184": "Incomplete List of Disallowed Inputs",
-    "CWE-185": "Incorrect Regular Expression",
-    "CWE-186": "Overly Restrictive Regular Expression",
-    "CWE-187": "Partial String Comparison",
-    "CWE-188": "Reliance on Data/Memory Layout",
-    "CWE-190": "Integer Overflow or Wraparound",
-    "CWE-191": "Integer Underflow",
-    "CWE-192": "Integer Coercion Error",
-    "CWE-193": "Off-by-one Error",
-    "CWE-194": "Unexpected Sign Extension",
-    "CWE-195": "Signed to Unsigned Conversion Error",
-    "CWE-196": "Unsigned to Signed Conversion Error",
-    "CWE-197": "Numeric Truncation Error",
-    "CWE-198": "Use of Incorrect Byte Ordering",
-    "CWE-200": "Exposure of Sensitive Information to an Unauthorized Actor",
-    "CWE-201": "Insertion of Sensitive Information Into Sent Data",
-    "CWE-202": "Exposure of Sensitive Information Through Data Queries",
-    "CWE-203": "Observable Discrepancy",
-    "CWE-204": "Observable Response Discrepancy",
-    "CWE-205": "Observable Behavioral Discrepancy",
-    "CWE-206": "Observable Internal Behavioral Discrepancy",
-    "CWE-207": "Observable Behavioral Discrepancy With Equivalent Products",
-    "CWE-208": "Observable Timing Discrepancy",
-    "CWE-209": "Generation of Error Message Containing Sensitive Information",
-    "CWE-210": "Self-generated Error Message Containing Sensitive Information",
-    "CWE-211": "Externally-Generated Error Message Containing Sensitive "
-    "Information",
-    "CWE-212": "Improper Removal of Sensitive Information Before Storage or "
-    "Transfer",
-    "CWE-213": "Exposure of Sensitive Information Due to Incompatible Policies",
-    "CWE-214": "Invocation of Process Using Visible Sensitive Information",
-    "CWE-215": "Insertion of Sensitive Information Into Debugging Code",
-    "CWE-216": "DEPRECATED: Containment Errors",
-    "CWE-217": "DEPRECATED: Failure to Protect Stored Data from Modification",
-    "CWE-218": "DEPRECATED: Failure to provide confidentiality for stored data",
-    "CWE-219": "Storage of File with Sensitive Data Under Web Root",
-    "CWE-220": "Storage of File With Sensitive Data Under FTP Root",
-    "CWE-221": "Information Loss or Omission",
-    "CWE-222": "Truncation of Security-relevant Information",
-    "CWE-223": "Omission of Security-relevant Information",
-    "CWE-224": "Obscured Security-relevant Information by Alternate Name",
-    "CWE-225": "DEPRECATED: General Information Management Problems",
-    "CWE-226": "Sensitive Information in Resource Not Removed Before Reuse",
-    "CWE-228": "Improper Handling of Syntactically Invalid Structure",
-    "CWE-229": "Improper Handling of Values",
-    "CWE-230": "Improper Handling of Missing Values",
-    "CWE-231": "Improper Handling of Extra Values",
-    "CWE-232": "Improper Handling of Undefined Values",
-    "CWE-233": "Improper Handling of Parameters",
-    "CWE-234": "Failure to Handle Missing Parameter",
-    "CWE-235": "Improper Handling of Extra Parameters",
-    "CWE-236": "Improper Handling of Undefined Parameters",
-    "CWE-237": "Improper Handling of Structural Elements",
-    "CWE-238": "Improper Handling of Incomplete Structural Elements",
-    "CWE-239": "Failure to Handle Incomplete Element",
-    "CWE-240": "Improper Handling of Inconsistent Structural Elements",
-    "CWE-241": "Improper Handling of Unexpected Data Type",
-    "CWE-242": "Use of Inherently Dangerous Function",
-    "CWE-243": "Creation of chroot Jail Without Changing Working Directory",
-    "CWE-244": "Improper Clearing of Heap Memory Before Release",
-    "CWE-245": "J2EE Bad Practices: Direct Management of Connections",
-    "CWE-246": "J2EE Bad Practices: Direct Use of Sockets",
-    "CWE-247": "DEPRECATED: Reliance on DNS Lookups in a Security Decision",
-    "CWE-248": "Uncaught Exception",
-    "CWE-249": "DEPRECATED: Often Misused: Path Manipulation",
-    "CWE-250": "Execution with Unnecessary Privileges",
-    "CWE-252": "Unchecked Return Value",
-    "CWE-253": "Incorrect Check of Function Return Value",
-    "CWE-256": "Plaintext Storage of a Password",
-    "CWE-257": "Storing Passwords in a Recoverable Format",
-    "CWE-258": "Empty Password in Configuration File",
-    "CWE-259": "Use of Hard-coded Password",
-    "CWE-260": "Password in Configuration File",
-    "CWE-261": "Weak Encoding for Password",
-    "CWE-262": "Not Using Password Aging",
-    "CWE-263": "Password Aging with Long Expiration",
-    "CWE-266": "Incorrect Privilege Assignment",
-    "CWE-267": "Privilege Defined With Unsafe Actions",
-    "CWE-268": "Privilege Chaining",
-    "CWE-269": "Improper Privilege Management",
-    "CWE-270": "Privilege Context Switching Error",
-    "CWE-271": "Privilege Dropping / Lowering Errors",
-    "CWE-272": "Least Privilege Violation",
-    "CWE-273": "Improper Check for Dropped Privileges",
-    "CWE-274": "Improper Handling of Insufficient Privileges",
-    "CWE-276": "Incorrect Default Permissions",
-    "CWE-277": "Insecure Inherited Permissions",
-    "CWE-278": "Insecure Preserved Inherited Permissions",
-    "CWE-279": "Incorrect Execution-Assigned Permissions",
-    "CWE-280": "Improper Handling of Insufficient Permissions or Privileges ",
-    "CWE-281": "Improper Preservation of Permissions",
-    "CWE-282": "Improper Ownership Management",
-    "CWE-283": "Unverified Ownership",
-    "CWE-284": "Improper Access Control",
-    "CWE-285": "Improper Authorization",
-    "CWE-286": "Incorrect User Management",
-    "CWE-287": "Improper Authentication",
-    "CWE-288": "Authentication Bypass Using an Alternate Path or Channel",
-    "CWE-289": "Authentication Bypass by Alternate Name",
-    "CWE-290": "Authentication Bypass by Spoofing",
-    "CWE-291": "Reliance on IP Address for Authentication",
-    "CWE-292": "DEPRECATED: Trusting Self-reported DNS Name",
-    "CWE-293": "Using Referer Field for Authentication",
-    "CWE-294": "Authentication Bypass by Capture-replay",
-    "CWE-295": "Improper Certificate Validation",
-    "CWE-296": "Improper Following of a Certificates Chain of Trust",
-    "CWE-297": "Improper Validation of Certificate with Host Mismatch",
-    "CWE-298": "Improper Validation of Certificate Expiration",
-    "CWE-299": "Improper Check for Certificate Revocation",
-    "CWE-300": "Channel Accessible by Non-Endpoint",
-    "CWE-301": "Reflection Attack in an Authentication Protocol",
-    "CWE-302": "Authentication Bypass by Assumed-Immutable Data",
-    "CWE-303": "Incorrect Implementation of Authentication Algorithm",
-    "CWE-304": "Missing Critical Step in Authentication",
-    "CWE-305": "Authentication Bypass by Primary Weakness",
-    "CWE-306": "Missing Authentication for Critical Function",
-    "CWE-307": "Improper Restriction of Excessive Authentication Attempts",
-    "CWE-308": "Use of Single-factor Authentication",
-    "CWE-309": "Use of Password System for Primary Authentication",
-    "CWE-311": "Missing Encryption of Sensitive Data",
-    "CWE-312": "Cleartext Storage of Sensitive Information",
-    "CWE-313": "Cleartext Storage in a File or on Disk",
-    "CWE-314": "Cleartext Storage in the Registry",
-    "CWE-315": "Cleartext Storage of Sensitive Information in a Cookie",
-    "CWE-316": "Cleartext Storage of Sensitive Information in Memory",
-    "CWE-317": "Cleartext Storage of Sensitive Information in GUI",
-    "CWE-318": "Cleartext Storage of Sensitive Information in Executable",
-    "CWE-319": "Cleartext Transmission of Sensitive Information",
-    "CWE-321": "Use of Hard-coded Cryptographic Key",
-    "CWE-322": "Key Exchange without Entity Authentication",
-    "CWE-323": "Reusing a Nonce, Key Pair in Encryption",
-    "CWE-324": "Use of a Key Past its Expiration Date",
-    "CWE-325": "Missing Cryptographic Step",
-    "CWE-326": "Inadequate Encryption Strength",
-    "CWE-327": "Use of a Broken or Risky Cryptographic Algorithm",
-    "CWE-328": "Use of Weak Hash",
-    "CWE-329": "Generation of Predictable IV with CBC Mode",
-    "CWE-330": "Use of Insufficiently Random Values",
-    "CWE-331": "Insufficient Entropy",
-    "CWE-332": "Insufficient Entropy in PRNG",
-    "CWE-333": "Improper Handling of Insufficient Entropy in TRNG",
-    "CWE-334": "Small Space of Random Values",
-    "CWE-335": "Incorrect Usage of Seeds in Pseudo-Random Number Generator",
-    "CWE-336": "Same Seed in Pseudo-Random Number Generator",
-    "CWE-337": "Predictable Seed in Pseudo-Random Number Generator",
-    "CWE-338": "Use of Cryptographically Weak Pseudo-Random Number Generator",
-    "CWE-339": "Small Seed Space in PRNG",
-    "CWE-340": "Generation of Predictable Numbers or Identifiers",
-    "CWE-341": "Predictable from Observable State",
-    "CWE-342": "Predictable Exact Value from Previous Values",
-    "CWE-343": "Predictable Value Range from Previous Values",
-    "CWE-344": "Use of Invariant Value in Dynamically Changing Context",
-    "CWE-345": "Insufficient Verification of Data Authenticity",
-    "CWE-346": "Origin Validation Error",
-    "CWE-347": "Improper Verification of Cryptographic Signature",
-    "CWE-348": "Use of Less Trusted Source",
-    "CWE-349": "Acceptance of Extraneous Untrusted Data With Trusted Data",
-    "CWE-350": "Reliance on Reverse DNS Resolution for a Security-Critical "
-    "Action",
-    "CWE-351": "Insufficient Type Distinction",
-    "CWE-352": "Cross-Site Request Forgery",
-    "CWE-353": "Missing Support for Integrity Check",
-    "CWE-354": "Improper Validation of Integrity Check Value",
-    "CWE-356": "Product UI does not Warn User of Unsafe Actions",
-    "CWE-357": "Insufficient UI Warning of Dangerous Operations",
-    "CWE-358": "Improperly Implemented Security Check for Standard",
-    "CWE-359": "Exposure of Private Personal Information to an Unauthorized "
-    "Actor",
-    "CWE-360": "Trust of System Event Data",
-    "CWE-362": "Concurrent Execution using Shared Resource with Improper "
-    "Synchronization",
-    "CWE-363": "Race Condition Enabling Link Following",
-    "CWE-364": "Signal Handler Race Condition",
-    "CWE-365": "DEPRECATED: Race Condition in Switch",
-    "CWE-366": "Race Condition within a Thread",
-    "CWE-367": "Time-of-check Time-of-use",
-    "CWE-368": "Context Switching Race Condition",
-    "CWE-369": "Divide By Zero",
-    "CWE-370": "Missing Check for Certificate Revocation after Initial Check",
-    "CWE-372": "Incomplete Internal State Distinction",
-    "CWE-373": "DEPRECATED: State Synchronization Error",
-    "CWE-374": "Passing Mutable Objects to an Untrusted Method",
-    "CWE-375": "Returning a Mutable Object to an Untrusted Caller",
-    "CWE-377": "Insecure Temporary File",
-    "CWE-378": "Creation of Temporary File With Insecure Permissions",
-    "CWE-379": "Creation of Temporary File in Directory with Insecure "
-    "Permissions",
-    "CWE-382": "J2EE Bad Practices: Use of System.exit",
-    "CWE-383": "J2EE Bad Practices: Direct Use of Threads",
-    "CWE-384": "Session Fixation",
-    "CWE-385": "Covert Timing Channel",
-    "CWE-386": "Symbolic Name not Mapping to Correct Object",
-    "CWE-390": "Detection of Error Condition Without Action",
-    "CWE-391": "Unchecked Error Condition",
-    "CWE-392": "Missing Report of Error Condition",
-    "CWE-393": "Return of Wrong Status Code",
-    "CWE-394": "Unexpected Status Code or Return Value",
-    "CWE-395": "Use of NullPointerException Catch to Detect NULL Pointer "
-    "Dereference",
-    "CWE-396": "Declaration of Catch for Generic Exception",
-    "CWE-397": "Declaration of Throws for Generic Exception",
-    "CWE-400": "Uncontrolled Resource Consumption",
-    "CWE-401": "Missing Release of Memory after Effective Lifetime",
-    "CWE-402": "Transmission of Private Resources into a New Sphere",
-    "CWE-403": "Exposure of File Descriptor to Unintended Control Sphere",
-    "CWE-404": "Improper Resource Shutdown or Release",
-    "CWE-405": "Asymmetric Resource Consumption",
-    "CWE-406": "Insufficient Control of Network Message Volume",
-    "CWE-407": "Inefficient Algorithmic Complexity",
-    "CWE-408": "Incorrect Behavior Order: Early Amplification",
-    "CWE-409": "Improper Handling of Highly Compressed Data",
-    "CWE-410": "Insufficient Resource Pool",
-    "CWE-412": "Unrestricted Externally Accessible Lock",
-    "CWE-413": "Improper Resource Locking",
-    "CWE-414": "Missing Lock Check",
-    "CWE-415": "Double Free",
-    "CWE-416": "Use After Free",
-    "CWE-419": "Unprotected Primary Channel",
-    "CWE-420": "Unprotected Alternate Channel",
-    "CWE-421": "Race Condition During Access to Alternate Channel",
-    "CWE-422": "Unprotected Windows Messaging Channel",
-    "CWE-423": "DEPRECATED: Proxied Trusted Channel",
-    "CWE-424": "Improper Protection of Alternate Path",
-    "CWE-425": "Direct Request",
-    "CWE-426": "Untrusted Search Path",
-    "CWE-427": "Uncontrolled Search Path Element",
-    "CWE-428": "Unquoted Search Path or Element",
-    "CWE-430": "Deployment of Wrong Handler",
-    "CWE-431": "Missing Handler",
-    "CWE-432": "Dangerous Signal Handler not Disabled During Sensitive "
-    "Operations",
-    "CWE-433": "Unparsed Raw Web Content Delivery",
-    "CWE-434": "Unrestricted Upload of File with Dangerous Type",
-    "CWE-435": "Improper Interaction Between Multiple Correctly-Behaving "
-    "Entities",
-    "CWE-436": "Interpretation Conflict",
-    "CWE-437": "Incomplete Model of Endpoint Features",
-    "CWE-439": "Behavioral Change in New Version or Environment",
-    "CWE-440": "Expected Behavior Violation",
-    "CWE-441": "Unintended Proxy or Intermediary",
-    "CWE-443": "DEPRECATED: HTTP response splitting",
-    "CWE-444": "Inconsistent Interpretation of HTTP Requests",
-    "CWE-446": "UI Discrepancy for Security Feature",
-    "CWE-447": "Unimplemented or Unsupported Feature in UI",
-    "CWE-448": "Obsolete Feature in UI",
-    "CWE-449": "The UI Performs the Wrong Action",
-    "CWE-450": "Multiple Interpretations of UI Input",
-    "CWE-451": "User Interface",
-    "CWE-453": "Insecure Default Variable Initialization",
-    "CWE-454": "External Initialization of Trusted Variables or Data Stores",
-    "CWE-455": "Non-exit on Failed Initialization",
-    "CWE-456": "Missing Initialization of a Variable",
-    "CWE-457": "Use of Uninitialized Variable",
-    "CWE-458": "DEPRECATED: Incorrect Initialization",
-    "CWE-459": "Incomplete Cleanup",
-    "CWE-460": "Improper Cleanup on Thrown Exception",
-    "CWE-462": "Duplicate Key in Associative List",
-    "CWE-463": "Deletion of Data Structure Sentinel",
-    "CWE-464": "Addition of Data Structure Sentinel",
-    "CWE-466": "Return of Pointer Value Outside of Expected Range",
-    "CWE-467": "Use of sizeof",
-    "CWE-468": "Incorrect Pointer Scaling",
-    "CWE-469": "Use of Pointer Subtraction to Determine Size",
-    "CWE-470": "Use of Externally-Controlled Input to Select Classes or Code",
-    "CWE-471": "Modification of Assumed-Immutable Data",
-    "CWE-472": "External Control of Assumed-Immutable Web Parameter",
-    "CWE-473": "PHP External Variable Modification",
-    "CWE-474": "Use of Function with Inconsistent Implementations",
-    "CWE-475": "Undefined Behavior for Input to API",
-    "CWE-476": "NULL Pointer Dereference",
-    "CWE-477": "Use of Obsolete Function",
-    "CWE-478": "Missing Default Case in Multiple Condition Expression",
-    "CWE-479": "Signal Handler Use of a Non-reentrant Function",
-    "CWE-480": "Use of Incorrect Operator",
-    "CWE-481": "Assigning instead of Comparing",
-    "CWE-482": "Comparing instead of Assigning",
-    "CWE-483": "Incorrect Block Delimitation",
-    "CWE-484": "Omitted Break Statement in Switch",
-    "CWE-486": "Comparison of Classes by Name",
-    "CWE-487": "Reliance on Package-level Scope",
-    "CWE-488": "Exposure of Data Element to Wrong Session",
-    "CWE-489": "Active Debug Code",
-    "CWE-491": "Public cloneable",
-    "CWE-492": "Use of Inner Class Containing Sensitive Data",
-    "CWE-493": "Critical Public Variable Without Final Modifier",
-    "CWE-494": "Download of Code Without Integrity Check",
-    "CWE-495": "Private Data Structure Returned From A Public Method",
-    "CWE-496": "Public Data Assigned to Private Array-Typed Field",
-    "CWE-497": "Exposure of Sensitive System Information to an Unauthorized "
-    "Control Sphere",
-    "CWE-498": "Cloneable Class Containing Sensitive Information",
-    "CWE-499": "Serializable Class Containing Sensitive Data",
-    "CWE-500": "Public Static Field Not Marked Final",
-    "CWE-501": "Trust Boundary Violation",
-    "CWE-502": "Deserialization of Untrusted Data",
-    "CWE-506": "Embedded Malicious Code",
-    "CWE-507": "Trojan Horse",
-    "CWE-508": "Non-Replicating Malicious Code",
-    "CWE-509": "Replicating Malicious Code",
-    "CWE-510": "Trapdoor",
-    "CWE-511": "Logic/Time Bomb",
-    "CWE-512": "Spyware",
-    "CWE-514": "Covert Channel",
-    "CWE-515": "Covert Storage Channel",
-    "CWE-516": "DEPRECATED: Covert Timing Channel",
-    "CWE-520": ".NET Misconfiguration: Use of Impersonation",
-    "CWE-521": "Weak Password Requirements",
-    "CWE-522": "Insufficiently Protected Credentials",
-    "CWE-523": "Unprotected Transport of Credentials",
-    "CWE-524": "Use of Cache Containing Sensitive Information",
-    "CWE-525": "Use of Web Browser Cache Containing Sensitive Information",
-    "CWE-526": "Cleartext Storage of Sensitive Information in an Environment "
-    "Variable",
-    "CWE-527": "Exposure of Version-Control Repository to an Unauthorized "
-    "Control Sphere",
-    "CWE-528": "Exposure of Core Dump File to an Unauthorized Control Sphere",
-    "CWE-529": "Exposure of Access Control List Files to an Unauthorized "
-    "Control Sphere",
-    "CWE-530": "Exposure of Backup File to an Unauthorized Control Sphere",
-    "CWE-531": "Inclusion of Sensitive Information in Test Code",
-    "CWE-532": "Insertion of Sensitive Information into Log File",
-    "CWE-533": "DEPRECATED: Information Exposure Through Server Log Files",
-    "CWE-534": "DEPRECATED: Information Exposure Through Debug Log Files",
-    "CWE-535": "Exposure of Information Through Shell Error Message",
-    "CWE-536": "Servlet Runtime Error Message Containing Sensitive Information",
-    "CWE-537": "Java Runtime Error Message Containing Sensitive Information",
-    "CWE-538": "Insertion of Sensitive Information into Externally-Accessible "
-    "File or Directory",
-    "CWE-539": "Use of Persistent Cookies Containing Sensitive Information",
-    "CWE-540": "Inclusion of Sensitive Information in Source Code",
-    "CWE-541": "Inclusion of Sensitive Information in an Include File",
-    "CWE-542": "DEPRECATED: Information Exposure Through Cleanup Log Files",
-    "CWE-543": "Use of Singleton Pattern Without Synchronization in a "
-    "Multithreaded Context",
-    "CWE-544": "Missing Standardized Error Handling Mechanism",
-    "CWE-545": "DEPRECATED: Use of Dynamic Class Loading",
-    "CWE-546": "Suspicious Comment",
-    "CWE-547": "Use of Hard-coded, Security-relevant Constants",
-    "CWE-548": "Exposure of Information Through Directory Listing",
-    "CWE-549": "Missing Password Field Masking",
-    "CWE-550": "Server-generated Error Message Containing Sensitive "
-    "Information",
-    "CWE-551": "Incorrect Behavior Order: Authorization Before Parsing and "
-    "Canonicalization",
-    "CWE-552": "Files or Directories Accessible to External Parties",
-    "CWE-553": "Command Shell in Externally Accessible Directory",
-    "CWE-554": "ASP.NET Misconfiguration: Not Using Input Validation Framework",
-    "CWE-555": "J2EE Misconfiguration: Plaintext Password in Configuration "
-    "File",
-    "CWE-556": "ASP.NET Misconfiguration: Use of Identity Impersonation",
-    "CWE-558": "Use of getlogin",
-    "CWE-560": "Use of umask",
-    "CWE-561": "Dead Code",
-    "CWE-562": "Return of Stack Variable Address",
-    "CWE-563": "Assignment to Variable without Use",
-    "CWE-564": "SQL Injection: Hibernate",
-    "CWE-565": "Reliance on Cookies without Validation and Integrity Checking",
-    "CWE-566": "Authorization Bypass Through User-Controlled SQL Primary Key",
-    "CWE-567": "Unsynchronized Access to Shared Data in a Multithreaded "
-    "Context",
-    "CWE-568": "finalize",
-    "CWE-570": "Expression is Always False",
-    "CWE-571": "Expression is Always True",
-    "CWE-572": "Call to Thread run",
-    "CWE-573": "Improper Following of Specification by Caller",
-    "CWE-574": "EJB Bad Practices: Use of Synchronization Primitives",
-    "CWE-575": "EJB Bad Practices: Use of AWT Swing",
-    "CWE-576": "EJB Bad Practices: Use of Java I/O",
-    "CWE-577": "EJB Bad Practices: Use of Sockets",
-    "CWE-578": "EJB Bad Practices: Use of Class Loader",
-    "CWE-579": "J2EE Bad Practices: Non-serializable Object Stored in Session",
-    "CWE-580": "clone",
-    "CWE-581": "Object Model Violation: Just One of Equals and Hashcode "
-    "Defined",
-    "CWE-582": "Array Declared Public, Final, and Static",
-    "CWE-583": "finalize",
-    "CWE-584": "Return Inside Finally Block",
-    "CWE-585": "Empty Synchronized Block",
-    "CWE-586": "Explicit Call to Finalize",
-    "CWE-587": "Assignment of a Fixed Address to a Pointer",
-    "CWE-588": "Attempt to Access Child of a Non-structure Pointer",
-    "CWE-589": "Call to Non-ubiquitous API",
-    "CWE-590": "Free of Memory not on the Heap",
-    "CWE-591": "Sensitive Data Storage in Improperly Locked Memory",
-    "CWE-592": "DEPRECATED: Authentication Bypass Issues",
-    "CWE-593": "Authentication Bypass: OpenSSL CTX Object Modified after SSL "
-    "Objects are Created",
-    "CWE-594": "J2EE Framework: Saving Unserializable Objects to Disk",
-    "CWE-595": "Comparison of Object References Instead of Object Contents",
-    "CWE-596": "DEPRECATED: Incorrect Semantic Object Comparison",
-    "CWE-597": "Use of Wrong Operator in String Comparison",
-    "CWE-598": "Use of GET Request Method With Sensitive Query Strings",
-    "CWE-599": "Missing Validation of OpenSSL Certificate",
-    "CWE-600": "Uncaught Exception in Servlet ",
-    "CWE-601": "URL Redirection to Untrusted Site",
-    "CWE-602": "Client-Side Enforcement of Server-Side Security",
-    "CWE-603": "Use of Client-Side Authentication",
-    "CWE-605": "Multiple Binds to the Same Port",
-    "CWE-606": "Unchecked Input for Loop Condition",
-    "CWE-607": "Public Static Final Field References Mutable Object",
-    "CWE-608": "Struts: Non-private Field in ActionForm Class",
-    "CWE-609": "Double-Checked Locking",
-    "CWE-610": "Externally Controlled Reference to a Resource in Another "
-    "Sphere",
-    "CWE-611": "Improper Restriction of XML External Entity Reference",
-    "CWE-612": "Improper Authorization of Index Containing Sensitive "
-    "Information",
-    "CWE-613": "Insufficient Session Expiration",
-    "CWE-614": "Sensitive Cookie in HTTPS Session Without Secure Attribute",
-    "CWE-615": "Inclusion of Sensitive Information in Source Code Comments",
-    "CWE-616": "Incomplete Identification of Uploaded File Variables",
-    "CWE-617": "Reachable Assertion",
-    "CWE-618": "Exposed Unsafe ActiveX Method",
-    "CWE-619": "Dangling Database Cursor",
-    "CWE-620": "Unverified Password Change",
-    "CWE-621": "Variable Extraction Error",
-    "CWE-622": "Improper Validation of Function Hook Arguments",
-    "CWE-623": "Unsafe ActiveX Control Marked Safe For Scripting",
-    "CWE-624": "Executable Regular Expression Error",
-    "CWE-625": "Permissive Regular Expression",
-    "CWE-626": "Null Byte Interaction Error",
-    "CWE-627": "Dynamic Variable Evaluation",
-    "CWE-628": "Function Call with Incorrectly Specified Arguments",
-    "CWE-636": "Not Failing Securely",
-    "CWE-637": "Unnecessary Complexity in Protection Mechanism",
-    "CWE-638": "Not Using Complete Mediation",
-    "CWE-639": "Authorization Bypass Through User-Controlled Key",
-    "CWE-640": "Weak Password Recovery Mechanism for Forgotten Password",
-    "CWE-641": "Improper Restriction of Names for Files and Other Resources",
-    "CWE-642": "External Control of Critical State Data",
-    "CWE-643": "Improper Neutralization of Data within XPath Expressions",
-    "CWE-644": "Improper Neutralization of HTTP Headers for Scripting Syntax",
-    "CWE-645": "Overly Restrictive Account Lockout Mechanism",
-    "CWE-646": "Reliance on File Name or Extension of Externally-Supplied File",
-    "CWE-647": "Use of Non-Canonical URL Paths for Authorization Decisions",
-    "CWE-648": "Incorrect Use of Privileged APIs",
-    "CWE-649": "Reliance on Obfuscation or Encryption of Security-Relevant "
-    "Inputs without Integrity Checking",
-    "CWE-650": "Trusting HTTP Permission Methods on the Server Side",
-    "CWE-651": "Exposure of WSDL File Containing Sensitive Information",
-    "CWE-652": "Improper Neutralization of Data within XQuery Expressions",
-    "CWE-653": "Improper Isolation or Compartmentalization",
-    "CWE-654": "Reliance on a Single Factor in a Security Decision",
-    "CWE-655": "Insufficient Psychological Acceptability",
-    "CWE-656": "Reliance on Security Through Obscurity",
-    "CWE-657": "Violation of Secure Design Principles",
-    "CWE-662": "Improper Synchronization",
-    "CWE-663": "Use of a Non-reentrant Function in a Concurrent Context",
-    "CWE-664": "Improper Control of a Resource Through its Lifetime",
-    "CWE-665": "Improper Initialization",
-    "CWE-666": "Operation on Resource in Wrong Phase of Lifetime",
-    "CWE-667": "Improper Locking",
-    "CWE-668": "Exposure of Resource to Wrong Sphere",
-    "CWE-669": "Incorrect Resource Transfer Between Spheres",
-    "CWE-670": "Always-Incorrect Control Flow Implementation",
-    "CWE-671": "Lack of Administrator Control over Security",
-    "CWE-672": "Operation on a Resource after Expiration or Release",
-    "CWE-673": "External Influence of Sphere Definition",
-    "CWE-674": "Uncontrolled Recursion",
-    "CWE-675": "Multiple Operations on Resource in Single-Operation Context",
-    "CWE-676": "Use of Potentially Dangerous Function",
-    "CWE-680": "Integer Overflow to Buffer Overflow",
-    "CWE-681": "Incorrect Conversion between Numeric Types",
-    "CWE-682": "Incorrect Calculation",
-    "CWE-683": "Function Call With Incorrect Order of Arguments",
-    "CWE-684": "Incorrect Provision of Specified Functionality",
-    "CWE-685": "Function Call With Incorrect Number of Arguments",
-    "CWE-686": "Function Call With Incorrect Argument Type",
-    "CWE-687": "Function Call With Incorrectly Specified Argument Value",
-    "CWE-688": "Function Call With Incorrect Variable or Reference as Argument",
-    "CWE-689": "Permission Race Condition During Resource Copy",
-    "CWE-690": "Unchecked Return Value to NULL Pointer Dereference",
-    "CWE-691": "Insufficient Control Flow Management",
-    "CWE-692": "Incomplete Denylist to Cross-Site Scripting",
-    "CWE-693": "Protection Mechanism Failure",
-    "CWE-694": "Use of Multiple Resources with Duplicate Identifier",
-    "CWE-695": "Use of Low-Level Functionality",
-    "CWE-696": "Incorrect Behavior Order",
-    "CWE-697": "Incorrect Comparison",
-    "CWE-698": "Execution After Redirect",
-    "CWE-703": "Improper Check or Handling of Exceptional Conditions",
-    "CWE-704": "Incorrect Type Conversion or Cast",
-    "CWE-705": "Incorrect Control Flow Scoping",
-    "CWE-706": "Use of Incorrectly-Resolved Name or Reference",
-    "CWE-707": "Improper Neutralization",
-    "CWE-708": "Incorrect Ownership Assignment",
-    "CWE-710": "Improper Adherence to Coding Standards",
-    "CWE-732": "Incorrect Permission Assignment for Critical Resource",
-    "CWE-733": "Compiler Optimization Removal or Modification of "
-    "Security-critical Code",
-    "CWE-749": "Exposed Dangerous Method or Function",
-    "CWE-754": "Improper Check for Unusual or Exceptional Conditions",
-    "CWE-755": "Improper Handling of Exceptional Conditions",
-    "CWE-756": "Missing Custom Error Page",
-    "CWE-757": "Selection of Less-Secure Algorithm During Negotiation",
-    "CWE-758": "Reliance on Undefined, Unspecified, or Implementation-Defined "
-    "Behavior",
-    "CWE-759": "Use of a One-Way Hash without a Salt",
-    "CWE-760": "Use of a One-Way Hash with a Predictable Salt",
-    "CWE-761": "Free of Pointer not at Start of Buffer",
-    "CWE-762": "Mismatched Memory Management Routines",
-    "CWE-763": "Release of Invalid Pointer or Reference",
-    "CWE-764": "Multiple Locks of a Critical Resource",
-    "CWE-765": "Multiple Unlocks of a Critical Resource",
-    "CWE-766": "Critical Data Element Declared Public",
-    "CWE-767": "Access to Critical Private Variable via Public Method",
-    "CWE-768": "Incorrect Short Circuit Evaluation",
-    "CWE-769": "DEPRECATED: Uncontrolled File Descriptor Consumption",
-    "CWE-770": "Allocation of Resources Without Limits or Throttling",
-    "CWE-771": "Missing Reference to Active Allocated Resource",
-    "CWE-772": "Missing Release of Resource after Effective Lifetime",
-    "CWE-773": "Missing Reference to Active File Descriptor or Handle",
-    "CWE-774": "Allocation of File Descriptors or Handles Without Limits or "
-    "Throttling",
-    "CWE-775": "Missing Release of File Descriptor or Handle after Effective "
-    "Lifetime",
-    "CWE-776": "Improper Restriction of Recursive Entity References in DTDs",
-    "CWE-777": "Regular Expression without Anchors",
-    "CWE-778": "Insufficient Logging",
-    "CWE-779": "Logging of Excessive Data",
-    "CWE-780": "Use of RSA Algorithm without OAEP",
-    "CWE-781": "Improper Address Validation in IOCTL with METHOD_NEITHER I/O "
-    "Control Code",
-    "CWE-782": "Exposed IOCTL with Insufficient Access Control",
-    "CWE-783": "Operator Precedence Logic Error",
-    "CWE-784": "Reliance on Cookies without Validation and Integrity Checking "
-    "in a Security Decision",
-    "CWE-785": "Use of Path Manipulation Function without Maximum-sized Buffer",
-    "CWE-786": "Access of Memory Location Before Start of Buffer",
-    "CWE-787": "Out-of-bounds Write",
-    "CWE-788": "Access of Memory Location After End of Buffer",
-    "CWE-789": "Memory Allocation with Excessive Size Value",
-    "CWE-790": "Improper Filtering of Special Elements",
-    "CWE-791": "Incomplete Filtering of Special Elements",
-    "CWE-792": "Incomplete Filtering of One or More Instances of Special "
-    "Elements",
-    "CWE-793": "Only Filtering One Instance of a Special Element",
-    "CWE-794": "Incomplete Filtering of Multiple Instances of Special Elements",
-    "CWE-795": "Only Filtering Special Elements at a Specified Location",
-    "CWE-796": "Only Filtering Special Elements Relative to a Marker",
-    "CWE-797": "Only Filtering Special Elements at an Absolute Position",
-    "CWE-798": "Use of Hard-coded Credentials",
-    "CWE-799": "Improper Control of Interaction Frequency",
-    "CWE-804": "Guessable CAPTCHA",
-    "CWE-805": "Buffer Access with Incorrect Length Value",
-    "CWE-806": "Buffer Access Using Size of Source Buffer",
-    "CWE-807": "Reliance on Untrusted Inputs in a Security Decision",
-    "CWE-820": "Missing Synchronization",
-    "CWE-821": "Incorrect Synchronization",
-    "CWE-822": "Untrusted Pointer Dereference",
-    "CWE-823": "Use of Out-of-range Pointer Offset",
-    "CWE-824": "Access of Uninitialized Pointer",
-    "CWE-825": "Expired Pointer Dereference",
-    "CWE-826": "Premature Release of Resource During Expected Lifetime",
-    "CWE-827": "Improper Control of Document Type Definition",
-    "CWE-828": "Signal Handler with Functionality that is not "
-    "Asynchronous-Safe",
-    "CWE-829": "Inclusion of Functionality from Untrusted Control Sphere",
-    "CWE-830": "Inclusion of Web Functionality from an Untrusted Source",
-    "CWE-831": "Signal Handler Function Associated with Multiple Signals",
-    "CWE-832": "Unlock of a Resource that is not Locked",
-    "CWE-833": "Deadlock",
-    "CWE-834": "Excessive Iteration",
-    "CWE-835": "Loop with Unreachable Exit Condition",
-    "CWE-836": "Use of Password Hash Instead of Password for Authentication",
-    "CWE-837": "Improper Enforcement of a Single, Unique Action",
-    "CWE-838": "Inappropriate Encoding for Output Context",
-    "CWE-839": "Numeric Range Comparison Without Minimum Check",
-    "CWE-841": "Improper Enforcement of Behavioral Workflow",
-    "CWE-842": "Placement of User into Incorrect Group",
-    "CWE-843": "Access of Resource Using Incompatible Type",
-    "CWE-862": "Missing Authorization",
-    "CWE-863": "Incorrect Authorization",
-    "CWE-908": "Use of Uninitialized Resource",
-    "CWE-909": "Missing Initialization of Resource",
-    "CWE-910": "Use of Expired File Descriptor",
-    "CWE-911": "Improper Update of Reference Count",
-    "CWE-912": "Hidden Functionality",
-    "CWE-913": "Improper Control of Dynamically-Managed Code Resources",
-    "CWE-914": "Improper Control of Dynamically-Identified Variables",
-    "CWE-915": "Improperly Controlled Modification of Dynamically-Determined "
-    "Object Attributes",
-    "CWE-916": "Use of Password Hash With Insufficient Computational Effort",
-    "CWE-917": "Improper Neutralization of Special Elements used in an "
-    "Expression Language Statement",
-    "CWE-918": "Server-Side Request Forgery",
-    "CWE-920": "Improper Restriction of Power Consumption",
-    "CWE-921": "Storage of Sensitive Data in a Mechanism without Access "
-    "Control",
-    "CWE-922": "Insecure Storage of Sensitive Information",
-    "CWE-923": "Improper Restriction of Communication Channel to Intended "
-    "Endpoints",
-    "CWE-924": "Improper Enforcement of Message Integrity During Transmission "
-    "in a Communication Channel",
-    "CWE-925": "Improper Verification of Intent by Broadcast Receiver",
-    "CWE-926": "Improper Export of Android Application Components",
-    "CWE-927": "Use of Implicit Intent for Sensitive Communication",
-    "CWE-939": "Improper Authorization in Handler for Custom URL Scheme",
-    "CWE-940": "Improper Verification of Source of a Communication Channel",
-    "CWE-941": "Incorrectly Specified Destination in a Communication Channel",
-    "CWE-942": "Permissive Cross-domain Policy with Untrusted Domains",
-    "CWE-943": "Improper Neutralization of Special Elements in Data Query "
-    "Logic",
-    "CWE-1004": "Sensitive Cookie Without HttpOnly Flag",
-    "CWE-1007": "Insufficient Visual Distinction of Homoglyphs Presented to "
-    "User",
-    "CWE-1021": "Improper Restriction of Rendered UI Layers or Frames",
-    "CWE-1022": "Use of Web Link to Untrusted Target with window.opener Access",
-    "CWE-1023": "Incomplete Comparison with Missing Factors",
-    "CWE-1024": "Comparison of Incompatible Types",
-    "CWE-1025": "Comparison Using Wrong Factors",
-    "CWE-1037": "Processor Optimization Removal or Modification of "
-    "Security-critical Code",
-    "CWE-1038": "Insecure Automated Optimizations",
-    "CWE-1039": "Automated Recognition Mechanism with Inadequate Detection or "
-    "Handling of Adversarial Input Perturbations",
-    "CWE-1041": "Use of Redundant Code",
-    "CWE-1042": "Static Member Data Element outside of a Singleton Class "
-    "Element",
-    "CWE-1043": "Data Element Aggregating an Excessively Large Number of "
-    "Non-Primitive Elements",
-    "CWE-1044": "Architecture with Number of Horizontal Layers Outside of "
-    "Expected Range",
-    "CWE-1045": "Parent Class with a Virtual Destructor and a Child Class "
-    "without a Virtual Destructor",
-    "CWE-1046": "Creation of Immutable Text Using String Concatenation",
-    "CWE-1047": "Modules with Circular Dependencies",
-    "CWE-1048": "Invokable Control Element with Large Number of Outward Calls",
-    "CWE-1049": "Excessive Data Query Operations in a Large Data Table",
-    "CWE-1050": "Excessive Platform Resource Consumption within a Loop",
-    "CWE-1051": "Initialization with Hard-Coded Network Resource "
-    "Configuration Data",
-    "CWE-1052": "Excessive Use of Hard-Coded Literals in Initialization",
-    "CWE-1053": "Missing Documentation for Design",
-    "CWE-1054": "Invocation of a Control Element at an Unnecessarily Deep "
-    "Horizontal Layer",
-    "CWE-1055": "Multiple Inheritance from Concrete Classes",
-    "CWE-1056": "Invokable Control Element with Variadic Parameters",
-    "CWE-1057": "Data Access Operations Outside of Expected Data Manager "
-    "Component",
-    "CWE-1058": "Invokable Control Element in Multi-Thread Context with "
-    "non-Final Static Storable or Member Element",
-    "CWE-1059": "Insufficient Technical Documentation",
-    "CWE-1060": "Excessive Number of Inefficient Server-Side Data Accesses",
-    "CWE-1061": "Insufficient Encapsulation",
-    "CWE-1062": "Parent Class with References to Child Class",
-    "CWE-1063": "Creation of Class Instance within a Static Code Block",
-    "CWE-1064": "Invokable Control Element with Signature Containing an "
-    "Excessive Number of Parameters",
-    "CWE-1065": "Runtime Resource Management Control Element in a Component "
-    "Built to Run on Application Servers",
-    "CWE-1066": "Missing Serialization Control Element",
-    "CWE-1067": "Excessive Execution of Sequential Searches of Data Resource",
-    "CWE-1068": "Inconsistency Between Implementation and Documented Design",
-    "CWE-1069": "Empty Exception Block",
-    "CWE-1070": "Serializable Data Element Containing non-Serializable Item "
-    "Elements",
-    "CWE-1071": "Empty Code Block",
-    "CWE-1072": "Data Resource Access without Use of Connection Pooling",
-    "CWE-1073": "Non-SQL Invokable Control Element with Excessive Number of "
-    "Data Resource Accesses",
-    "CWE-1074": "Class with Excessively Deep Inheritance",
-    "CWE-1075": "Unconditional Control Flow Transfer outside of Switch Block",
-    "CWE-1076": "Insufficient Adherence to Expected Conventions",
-    "CWE-1077": "Floating Point Comparison with Incorrect Operator",
-    "CWE-1078": "Inappropriate Source Code Style or Formatting",
-    "CWE-1079": "Parent Class without Virtual Destructor Method",
-    "CWE-1080": "Source Code File with Excessive Number of Lines of Code",
-    "CWE-1082": "Class Instance Self Destruction Control Element",
-    "CWE-1083": "Data Access from Outside Expected Data Manager Component",
-    "CWE-1084": "Invokable Control Element with Excessive File or Data Access "
-    "Operations",
-    "CWE-1085": "Invokable Control Element with Excessive Volume of "
-    "Commented-out Code",
-    "CWE-1086": "Class with Excessive Number of Child Classes",
-    "CWE-1087": "Class with Virtual Method without a Virtual Destructor",
-    "CWE-1088": "Synchronous Access of Remote Resource without Timeout",
-    "CWE-1089": "Large Data Table with Excessive Number of Indices",
-    "CWE-1090": "Method Containing Access of a Member Element from Another "
-    "Class",
-    "CWE-1091": "Use of Object without Invoking Destructor Method",
-    "CWE-1092": "Use of Same Invokable Control Element in Multiple "
-    "Architectural Layers",
-    "CWE-1093": "Excessively Complex Data Representation",
-    "CWE-1094": "Excessive Index Range Scan for a Data Resource",
-    "CWE-1095": "Loop Condition Value Update within the Loop",
-    "CWE-1096": "Singleton Class Instance Creation without Proper Locking or "
-    "Synchronization",
-    "CWE-1097": "Persistent Storable Data Element without Associated "
-    "Comparison Control Element",
-    "CWE-1098": "Data Element containing Pointer Item without Proper Copy "
-    "Control Element",
-    "CWE-1099": "Inconsistent Naming Conventions for Identifiers",
-    "CWE-1100": "Insufficient Isolation of System-Dependent Functions",
-    "CWE-1101": "Reliance on Runtime Component in Generated Code",
-    "CWE-1102": "Reliance on Machine-Dependent Data Representation",
-    "CWE-1103": "Use of Platform-Dependent Third Party Components",
-    "CWE-1104": "Use of Unmaintained Third Party Components",
-    "CWE-1105": "Insufficient Encapsulation of Machine-Dependent Functionality",
-    "CWE-1106": "Insufficient Use of Symbolic Constants",
-    "CWE-1107": "Insufficient Isolation of Symbolic Constant Definitions",
-    "CWE-1108": "Excessive Reliance on Global Variables",
-    "CWE-1109": "Use of Same Variable for Multiple Purposes",
-    "CWE-1110": "Incomplete Design Documentation",
-    "CWE-1111": "Incomplete I/O Documentation",
-    "CWE-1112": "Incomplete Documentation of Program Execution",
-    "CWE-1113": "Inappropriate Comment Style",
-    "CWE-1114": "Inappropriate Whitespace Style",
-    "CWE-1115": "Source Code Element without Standard Prologue",
-    "CWE-1116": "Inaccurate Comments",
-    "CWE-1117": "Callable with Insufficient Behavioral Summary",
-    "CWE-1118": "Insufficient Documentation of Error Handling Techniques",
-    "CWE-1119": "Excessive Use of Unconditional Branching",
-    "CWE-1120": "Excessive Code Complexity",
-    "CWE-1121": "Excessive McCabe Cyclomatic Complexity",
-    "CWE-1122": "Excessive Halstead Complexity",
-    "CWE-1123": "Excessive Use of Self-Modifying Code",
-    "CWE-1124": "Excessively Deep Nesting",
-    "CWE-1125": "Excessive Attack Surface",
-    "CWE-1126": "Declaration of Variable with Unnecessarily Wide Scope",
-    "CWE-1127": "Compilation with Insufficient Warnings or Errors",
-    "CWE-1164": "Irrelevant Code",
-    "CWE-1173": "Improper Use of Validation Framework",
-    "CWE-1174": "ASP.NET Misconfiguration: Improper Model Validation",
-    "CWE-1176": "Inefficient CPU Computation",
-    "CWE-1177": "Use of Prohibited Code",
-    "CWE-1187": "DEPRECATED: Use of Uninitialized Resource",
-    "CWE-1188": "Insecure Default Initialization of Resource",
-    "CWE-1189": "Improper Isolation of Shared Resources on System-on-a-Chip",
-    "CWE-1190": "DMA Device Enabled Too Early in Boot Phase",
-    "CWE-1191": "On-Chip Debug and Test Interface With Improper Access Control",
-    "CWE-1192": "System-on-Chip",
-    "CWE-1193": "Power-On of Untrusted Execution Core Before Enabling Fabric "
-    "Access Control",
-    "CWE-1204": "Generation of Weak Initialization Vector",
-    "CWE-1209": "Failure to Disable Reserved Bits",
-    "CWE-1220": "Insufficient Granularity of Access Control",
-    "CWE-1221": "Incorrect Register Defaults or Module Parameters",
-    "CWE-1222": "Insufficient Granularity of Address Regions Protected by "
-    "Register Locks",
-    "CWE-1223": "Race Condition for Write-Once Attributes",
-    "CWE-1224": "Improper Restriction of Write-Once Bit Fields",
-    "CWE-1229": "Creation of Emergent Resource",
-    "CWE-1230": "Exposure of Sensitive Information Through Metadata",
-    "CWE-1231": "Improper Prevention of Lock Bit Modification",
-    "CWE-1232": "Improper Lock Behavior After Power State Transition",
-    "CWE-1233": "Security-Sensitive Hardware Controls with Missing Lock Bit "
-    "Protection",
-    "CWE-1234": "Hardware Internal or Debug Modes Allow Override of Locks",
-    "CWE-1235": "Incorrect Use of Autoboxing and Unboxing for Performance "
-    "Critical Operations",
-    "CWE-1236": "Improper Neutralization of Formula Elements in a CSV File",
-    "CWE-1239": "Improper Zeroization of Hardware Register",
-    "CWE-1240": "Use of a Cryptographic Primitive with a Risky Implementation",
-    "CWE-1241": "Use of Predictable Algorithm in Random Number Generator",
-    "CWE-1242": "Inclusion of Undocumented Features or Chicken Bits",
-    "CWE-1243": "Sensitive Non-Volatile Information Not Protected During Debug",
-    "CWE-1244": "Internal Asset Exposed to Unsafe Debug Access Level or State",
-    "CWE-1245": "Improper Finite State Machines",
-    "CWE-1246": "Improper Write Handling in Limited-write Non-Volatile "
-    "Memories",
-    "CWE-1247": "Improper Protection Against Voltage and Clock Glitches",
-    "CWE-1248": "Semiconductor Defects in Hardware Logic with "
-    "Security-Sensitive Implications",
-    "CWE-1249": "Application-Level Admin Tool with Inconsistent View of "
-    "Underlying Operating System",
-    "CWE-1250": "Improper Preservation of Consistency Between Independent "
-    "Representations of Shared State",
-    "CWE-1251": "Mirrored Regions with Different Values",
-    "CWE-1252": "CPU Hardware Not Configured to Support Exclusivity of Write "
-    "and Execute Operations",
-    "CWE-1253": "Incorrect Selection of Fuse Values",
-    "CWE-1254": "Incorrect Comparison Logic Granularity",
-    "CWE-1255": "Comparison Logic is Vulnerable to Power Side-Channel Attacks",
-    "CWE-1256": "Improper Restriction of Software Interfaces to Hardware "
-    "Features",
-    "CWE-1257": "Improper Access Control Applied to Mirrored or Aliased "
-    "Memory Regions",
-    "CWE-1258": "Exposure of Sensitive System Information Due to Uncleared "
-    "Debug Information",
-    "CWE-1259": "Improper Restriction of Security Token Assignment",
-    "CWE-1260": "Improper Handling of Overlap Between Protected Memory Ranges",
-    "CWE-1261": "Improper Handling of Single Event Upsets",
-    "CWE-1262": "Improper Access Control for Register Interface",
-    "CWE-1263": "Improper Physical Access Control",
-    "CWE-1264": "Hardware Logic with Insecure De-Synchronization between "
-    "Control and Data Channels",
-    "CWE-1265": "Unintended Reentrant Invocation of Non-reentrant Code Via "
-    "Nested Calls",
-    "CWE-1266": "Improper Scrubbing of Sensitive Data from Decommissioned "
-    "Device",
-    "CWE-1267": "Policy Uses Obsolete Encoding",
-    "CWE-1268": "Policy Privileges are not Assigned Consistently Between "
-    "Control and Data Agents",
-    "CWE-1269": "Product Released in Non-Release Configuration",
-    "CWE-1270": "Generation of Incorrect Security Tokens",
-    "CWE-1271": "Uninitialized Value on Reset for Registers Holding Security "
-    "Settings",
-    "CWE-1272": "Sensitive Information Uncleared Before Debug/Power State "
-    "Transition",
-    "CWE-1273": "Device Unlock Credential Sharing",
-    "CWE-1274": "Improper Access Control for Volatile Memory Containing Boot "
-    "Code",
-    "CWE-1275": "Sensitive Cookie with Improper SameSite Attribute",
-    "CWE-1276": "Hardware Child Block Incorrectly Connected to Parent System",
-    "CWE-1277": "Firmware Not Updateable",
-    "CWE-1278": "Missing Protection Against Hardware Reverse Engineering "
-    "Using Integrated Circuit",
-    "CWE-1279": "Cryptographic Operations are run Before Supporting Units are "
-    "Ready",
-    "CWE-1280": "Access Control Check Implemented After Asset is Accessed",
-    "CWE-1281": "Sequence of Processor Instructions Leads to Unexpected "
-    "Behavior",
-    "CWE-1282": "Assumed-Immutable Data is Stored in Writable Memory",
-    "CWE-1283": "Mutable Attestation or Measurement Reporting Data",
-    "CWE-1284": "Improper Validation of Specified Quantity in Input",
-    "CWE-1285": "Improper Validation of Specified Index, Position, or Offset "
-    "in Input",
-    "CWE-1286": "Improper Validation of Syntactic Correctness of Input",
-    "CWE-1287": "Improper Validation of Specified Type of Input",
-    "CWE-1288": "Improper Validation of Consistency within Input",
-    "CWE-1289": "Improper Validation of Unsafe Equivalence in Input",
-    "CWE-1290": "Incorrect Decoding of Security Identifiers ",
-    "CWE-1291": "Public Key Re-Use for Signing both Debug and Production Code",
-    "CWE-1292": "Incorrect Conversion of Security Identifiers",
-    "CWE-1293": "Missing Source Correlation of Multiple Independent Data",
-    "CWE-1294": "Insecure Security Identifier Mechanism",
-    "CWE-1295": "Debug Messages Revealing Unnecessary Information",
-    "CWE-1296": "Incorrect Chaining or Granularity of Debug Components",
-    "CWE-1297": "Unprotected Confidential Information on Device is Accessible "
-    "by OSAT Vendors",
-    "CWE-1298": "Hardware Logic Contains Race Conditions",
-    "CWE-1299": "Missing Protection Mechanism for Alternate Hardware Interface",
-    "CWE-1300": "Improper Protection of Physical Side Channels",
-    "CWE-1301": "Insufficient or Incomplete Data Removal within Hardware "
-    "Component",
-    "CWE-1302": "Missing Security Identifier",
-    "CWE-1303": "Non-Transparent Sharing of Microarchitectural Resources",
-    "CWE-1304": "Improperly Preserved Integrity of Hardware Configuration "
-    "State During a Power Save/Restore Operation",
-    "CWE-1310": "Missing Ability to Patch ROM Code",
-    "CWE-1311": "Improper Translation of Security Attributes by Fabric Bridge",
-    "CWE-1312": "Missing Protection for Mirrored Regions in On-Chip Fabric "
-    "Firewall",
-    "CWE-1313": "Hardware Allows Activation of Test or Debug Logic at Runtime",
-    "CWE-1314": "Missing Write Protection for Parametric Data Values",
-    "CWE-1315": "Improper Setting of Bus Controlling Capability in Fabric "
-    "End-point",
-    "CWE-1316": "Fabric-Address Map Allows Programming of Unwarranted "
-    "Overlaps of Protected and Unprotected Ranges",
-    "CWE-1317": "Improper Access Control in Fabric Bridge",
-    "CWE-1318": "Missing Support for Security Features in On-chip Fabrics or "
-    "Buses",
-    "CWE-1319": "Improper Protection against Electromagnetic Fault Injection",
-    "CWE-1320": "Improper Protection for Outbound Error Messages and Alert "
-    "Signals",
-    "CWE-1321": "Improperly Controlled Modification of Object Prototype "
-    "Attributes",
-    "CWE-1322": "Use of Blocking Code in Single-threaded, Non-blocking Context",
-    "CWE-1323": "Improper Management of Sensitive Trace Data",
-    "CWE-1324": "DEPRECATED: Sensitive Information Accessible by Physical "
-    "Probing of JTAG Interface",
-    "CWE-1325": "Improperly Controlled Sequential Memory Allocation",
-    "CWE-1326": "Missing Immutable Root of Trust in Hardware",
-    "CWE-1327": "Binding to an Unrestricted IP Address",
-    "CWE-1328": "Security Version Number Mutable to Older Versions",
-    "CWE-1329": "Reliance on Component That is Not Updateable",
-    "CWE-1330": "Remanent Data Readable after Memory Erase",
-    "CWE-1331": "Improper Isolation of Shared Resources in Network On Chip",
-    "CWE-1332": "Improper Handling of Faults that Lead to Instruction Skips",
-    "CWE-1333": "Inefficient Regular Expression Complexity",
-    "CWE-1334": "Unauthorized Error Injection Can Degrade Hardware Redundancy",
-    "CWE-1335": "Incorrect Bitwise Shift of Integer",
-    "CWE-1336": "Improper Neutralization of Special Elements Used in a "
-    "Template Engine",
-    "CWE-1338": "Improper Protections Against Hardware Overheating",
-    "CWE-1339": "Insufficient Precision or Accuracy of a Real Number",
-    "CWE-1341": "Multiple Releases of Same Resource or Handle",
-    "CWE-1342": "Information Exposure through Microarchitectural State after "
-    "Transient Execution",
-    "CWE-1351": "Improper Handling of Hardware Behavior in Exceptionally Cold "
-    "Environments",
-    "CWE-1357": "Reliance on Insufficiently Trustworthy Component",
-    "CWE-1384": "Improper Handling of Physical or Environmental Conditions",
-    "CWE-1385": "Missing Origin Validation in WebSockets",
-    "CWE-1386": "Insecure Operation on Windows Junction / Mount Point",
-    "CWE-1389": "Incorrect Parsing of Numbers with Different Radices",
-    "CWE-1390": "Weak Authentication",
-    "CWE-1391": "Use of Weak Credentials",
-    "CWE-1392": "Use of Default Credentials",
-    "CWE-1393": "Use of Default Password",
-    "CWE-1394": "Use of Default Cryptographic Key",
-    "CWE-1395": "Dependency on Vulnerable Third-Party Component",
+    5: 'J2EE Misconfiguration: Data Transmission Without Encryption',
+    6: 'J2EE Misconfiguration: Insufficient Session-ID Length',
+    7: 'J2EE Misconfiguration: Missing Custom Error Page',
+    8: 'J2EE Misconfiguration: Entity Bean Declared Remote',
+    9: 'J2EE Misconfiguration: Weak Access Permissions for EJB Methods',
+    11: 'ASP.NET Misconfiguration: Creating Debug Binary',
+    12: 'ASP.NET Misconfiguration: Missing Custom Error Page',
+    13: 'ASP.NET Misconfiguration: Password in Configuration File',
+    14: 'Compiler Removal of Code to Clear Buffers',
+    15: 'External Control of System or Configuration Setting',
+    20: 'Improper Input Validation',
+    22: 'Improper Limitation of a Pathname to a Restricted Directory',
+    23: 'Relative Path Traversal',
+    24: 'Path Traversal',
+    25: 'Path Traversal',
+    26: 'Path Traversal',
+    27: 'Path Traversal',
+    28: 'Path Traversal',
+    29: 'Path Traversal',
+    30: 'Path Traversal',
+    31: 'Path Traversal',
+    32: 'Path Traversal',
+    33: 'Path Traversal',
+    34: 'Path Traversal',
+    35: 'Path Traversal',
+    36: 'Absolute Path Traversal',
+    37: 'Path Traversal',
+    38: 'Path Traversal',
+    39: 'Path Traversal',
+    40: 'Path Traversal',
+    41: 'Improper Resolution of Path Equivalence',
+    42: 'Path Equivalence',
+    43: 'Path Equivalence',
+    44: 'Path Equivalence',
+    45: 'Path Equivalence',
+    46: 'Path Equivalence',
+    47: 'Path Equivalence',
+    48: 'Path Equivalence',
+    49: 'Path Equivalence',
+    50: 'Path Equivalence',
+    51: 'Path Equivalence',
+    52: 'Path Equivalence',
+    53: 'Path Equivalence',
+    54: 'Path Equivalence',
+    55: 'Path Equivalence',
+    56: 'Path Equivalence',
+    57: 'Path Equivalence',
+    58: 'Path Equivalence',
+    59: 'Improper Link Resolution Before File Access',
+    61: 'UNIX Symbolic Link',
+    62: 'UNIX Hard Link',
+    64: 'Windows Shortcut Following',
+    65: 'Windows Hard Link',
+    66: 'Improper Handling of File Names that Identify Virtual Resources',
+    67: 'Improper Handling of Windows Device Names',
+    69: 'Improper Handling of Windows ::DATA Alternate Data Stream',
+    71: 'DEPRECATED: Apple .DS_Store',
+    72: 'Improper Handling of Apple HFS+ Alternate Data Stream Path',
+    73: 'External Control of File Name or Path',
+    74: 'Improper Neutralization of Special Elements in Output Used by a '
+        'Downstream Component',
+    75: 'Failure to Sanitize Special Elements into a Different Plane',
+    76: 'Improper Neutralization of Equivalent Special Elements',
+    77: 'Improper Neutralization of Special Elements used in a Command',
+    78: 'Improper Neutralization of Special Elements used in an OS Command',
+    79: 'Improper Neutralization of Input During Web Page Generation',
+    80: 'Improper Neutralization of Script-Related HTML Tags in a Web Page',
+    81: 'Improper Neutralization of Script in an Error Message Web Page',
+    82: 'Improper Neutralization of Script in Attributes of IMG Tags in a Web '
+        'Page',
+    83: 'Improper Neutralization of Script in Attributes in a Web Page',
+    84: 'Improper Neutralization of Encoded URI Schemes in a Web Page',
+    85: 'Doubled Character XSS Manipulations',
+    86: 'Improper Neutralization of Invalid Characters in Identifiers in Web '
+        'Pages',
+    87: 'Improper Neutralization of Alternate XSS Syntax',
+    88: 'Improper Neutralization of Argument Delimiters in a Command',
+    89: 'Improper Neutralization of Special Elements used in an SQL Command',
+    90: 'Improper Neutralization of Special Elements used in an LDAP Query',
+    91: 'XML Injection',
+    92: 'DEPRECATED: Improper Sanitization of Custom Special Characters',
+    93: 'Improper Neutralization of CRLF Sequences',
+    94: 'Improper Control of Generation of Code',
+    95: 'Improper Neutralization of Directives in Dynamically Evaluated Code',
+    96: 'Improper Neutralization of Directives in Statically Saved Code',
+    97: 'Improper Neutralization of Server-Side Includes',
+    98: 'Improper Control of Filename for Include/Require Statement in PHP '
+        'Program',
+    99: 'Improper Control of Resource Identifiers',
+    102: 'Struts: Duplicate Validation Forms',
+    103: 'Struts: Incomplete validate',
+    104: 'Struts: Form Bean Does Not Extend Validation Class',
+    105: 'Struts: Form Field Without Validator',
+    106: 'Struts: Plug-in Framework not in Use',
+    107: 'Struts: Unused Validation Form',
+    108: 'Struts: Unvalidated Action Form',
+    109: 'Struts: Validator Turned Off',
+    110: 'Struts: Validator Without Form Field',
+    111: 'Direct Use of Unsafe JNI',
+    112: 'Missing XML Validation',
+    113: 'Improper Neutralization of CRLF Sequences in HTTP Headers',
+    114: 'Process Control',
+    115: 'Misinterpretation of Input',
+    116: 'Improper Encoding or Escaping of Output',
+    117: 'Improper Output Neutralization for Logs',
+    118: 'Incorrect Access of Indexable Resource',
+    119: 'Improper Restriction of Operations within the Bounds of a Memory '
+         'Buffer',
+    120: 'Buffer Copy without Checking Size of Input',
+    121: 'Stack-based Buffer Overflow',
+    122: 'Heap-based Buffer Overflow',
+    123: 'Write-what-where Condition',
+    124: 'Buffer Underwrite',
+    125: 'Out-of-bounds Read',
+    126: 'Buffer Over-read',
+    127: 'Buffer Under-read',
+    128: 'Wrap-around Error',
+    129: 'Improper Validation of Array Index',
+    130: 'Improper Handling of Length Parameter Inconsistency',
+    131: 'Incorrect Calculation of Buffer Size',
+    132: 'DEPRECATED: Miscalculated Null Termination',
+    134: 'Use of Externally-Controlled Format String',
+    135: 'Incorrect Calculation of Multi-Byte String Length',
+    138: 'Improper Neutralization of Special Elements',
+    140: 'Improper Neutralization of Delimiters',
+    141: 'Improper Neutralization of Parameter/Argument Delimiters',
+    142: 'Improper Neutralization of Value Delimiters',
+    143: 'Improper Neutralization of Record Delimiters',
+    144: 'Improper Neutralization of Line Delimiters',
+    145: 'Improper Neutralization of Section Delimiters',
+    146: 'Improper Neutralization of Expression/Command Delimiters',
+    147: 'Improper Neutralization of Input Terminators',
+    148: 'Improper Neutralization of Input Leaders',
+    149: 'Improper Neutralization of Quoting Syntax',
+    150: 'Improper Neutralization of Escape, Meta, or Control Sequences',
+    151: 'Improper Neutralization of Comment Delimiters',
+    152: 'Improper Neutralization of Macro Symbols',
+    153: 'Improper Neutralization of Substitution Characters',
+    154: 'Improper Neutralization of Variable Name Delimiters',
+    155: 'Improper Neutralization of Wildcards or Matching Symbols',
+    156: 'Improper Neutralization of Whitespace',
+    157: 'Failure to Sanitize Paired Delimiters',
+    158: 'Improper Neutralization of Null Byte or NUL Character',
+    159: 'Improper Handling of Invalid Use of Special Elements',
+    160: 'Improper Neutralization of Leading Special Elements',
+    161: 'Improper Neutralization of Multiple Leading Special Elements',
+    162: 'Improper Neutralization of Trailing Special Elements',
+    163: 'Improper Neutralization of Multiple Trailing Special Elements',
+    164: 'Improper Neutralization of Internal Special Elements',
+    165: 'Improper Neutralization of Multiple Internal Special Elements',
+    166: 'Improper Handling of Missing Special Element',
+    167: 'Improper Handling of Additional Special Element',
+    168: 'Improper Handling of Inconsistent Special Elements',
+    170: 'Improper Null Termination',
+    172: 'Encoding Error',
+    173: 'Improper Handling of Alternate Encoding',
+    174: 'Double Decoding of the Same Data',
+    175: 'Improper Handling of Mixed Encoding',
+    176: 'Improper Handling of Unicode Encoding',
+    177: 'Improper Handling of URL Encoding',
+    178: 'Improper Handling of Case Sensitivity',
+    179: 'Incorrect Behavior Order: Early Validation',
+    180: 'Incorrect Behavior Order: Validate Before Canonicalize',
+    181: 'Incorrect Behavior Order: Validate Before Filter',
+    182: 'Collapse of Data into Unsafe Value',
+    183: 'Permissive List of Allowed Inputs',
+    184: 'Incomplete List of Disallowed Inputs',
+    185: 'Incorrect Regular Expression',
+    186: 'Overly Restrictive Regular Expression',
+    187: 'Partial String Comparison',
+    188: 'Reliance on Data/Memory Layout',
+    190: 'Integer Overflow or Wraparound',
+    191: 'Integer Underflow',
+    192: 'Integer Coercion Error',
+    193: 'Off-by-one Error',
+    194: 'Unexpected Sign Extension',
+    195: 'Signed to Unsigned Conversion Error',
+    196: 'Unsigned to Signed Conversion Error',
+    197: 'Numeric Truncation Error',
+    198: 'Use of Incorrect Byte Ordering',
+    200: 'Exposure of Sensitive Information to an Unauthorized Actor',
+    201: 'Insertion of Sensitive Information Into Sent Data',
+    202: 'Exposure of Sensitive Information Through Data Queries',
+    203: 'Observable Discrepancy',
+    204: 'Observable Response Discrepancy',
+    205: 'Observable Behavioral Discrepancy',
+    206: 'Observable Internal Behavioral Discrepancy',
+    207: 'Observable Behavioral Discrepancy With Equivalent Products',
+    208: 'Observable Timing Discrepancy',
+    209: 'Generation of Error Message Containing Sensitive Information',
+    210: 'Self-generated Error Message Containing Sensitive Information',
+    211: 'Externally-Generated Error Message Containing Sensitive Information',
+    212: 'Improper Removal of Sensitive Information Before Storage or Transfer',
+    213: 'Exposure of Sensitive Information Due to Incompatible Policies',
+    214: 'Invocation of Process Using Visible Sensitive Information',
+    215: 'Insertion of Sensitive Information Into Debugging Code',
+    216: 'DEPRECATED: Containment Errors',
+    217: 'DEPRECATED: Failure to Protect Stored Data from Modification',
+    218: 'DEPRECATED: Failure to provide confidentiality for stored data',
+    219: 'Storage of File with Sensitive Data Under Web Root',
+    220: 'Storage of File With Sensitive Data Under FTP Root',
+    221: 'Information Loss or Omission',
+    222: 'Truncation of Security-relevant Information',
+    223: 'Omission of Security-relevant Information',
+    224: 'Obscured Security-relevant Information by Alternate Name',
+    225: 'DEPRECATED: General Information Management Problems',
+    226: 'Sensitive Information in Resource Not Removed Before Reuse',
+    228: 'Improper Handling of Syntactically Invalid Structure',
+    229: 'Improper Handling of Values',
+    230: 'Improper Handling of Missing Values',
+    231: 'Improper Handling of Extra Values',
+    232: 'Improper Handling of Undefined Values',
+    233: 'Improper Handling of Parameters',
+    234: 'Failure to Handle Missing Parameter',
+    235: 'Improper Handling of Extra Parameters',
+    236: 'Improper Handling of Undefined Parameters',
+    237: 'Improper Handling of Structural Elements',
+    238: 'Improper Handling of Incomplete Structural Elements',
+    239: 'Failure to Handle Incomplete Element',
+    240: 'Improper Handling of Inconsistent Structural Elements',
+    241: 'Improper Handling of Unexpected Data Type',
+    242: 'Use of Inherently Dangerous Function',
+    243: 'Creation of chroot Jail Without Changing Working Directory',
+    244: 'Improper Clearing of Heap Memory Before Release',
+    245: 'J2EE Bad Practices: Direct Management of Connections',
+    246: 'J2EE Bad Practices: Direct Use of Sockets',
+    247: 'DEPRECATED: Reliance on DNS Lookups in a Security Decision',
+    248: 'Uncaught Exception',
+    249: 'DEPRECATED: Often Misused: Path Manipulation',
+    250: 'Execution with Unnecessary Privileges',
+    252: 'Unchecked Return Value',
+    253: 'Incorrect Check of Function Return Value',
+    256: 'Plaintext Storage of a Password',
+    257: 'Storing Passwords in a Recoverable Format',
+    258: 'Empty Password in Configuration File',
+    259: 'Use of Hard-coded Password',
+    260: 'Password in Configuration File',
+    261: 'Weak Encoding for Password',
+    262: 'Not Using Password Aging',
+    263: 'Password Aging with Long Expiration',
+    266: 'Incorrect Privilege Assignment',
+    267: 'Privilege Defined With Unsafe Actions',
+    268: 'Privilege Chaining',
+    269: 'Improper Privilege Management',
+    270: 'Privilege Context Switching Error',
+    271: 'Privilege Dropping / Lowering Errors',
+    272: 'Least Privilege Violation',
+    273: 'Improper Check for Dropped Privileges',
+    274: 'Improper Handling of Insufficient Privileges',
+    276: 'Incorrect Default Permissions',
+    277: 'Insecure Inherited Permissions',
+    278: 'Insecure Preserved Inherited Permissions',
+    279: 'Incorrect Execution-Assigned Permissions',
+    280: 'Improper Handling of Insufficient Permissions or Privileges ',
+    281: 'Improper Preservation of Permissions',
+    282: 'Improper Ownership Management',
+    283: 'Unverified Ownership',
+    284: 'Improper Access Control',
+    285: 'Improper Authorization',
+    286: 'Incorrect User Management',
+    287: 'Improper Authentication',
+    288: 'Authentication Bypass Using an Alternate Path or Channel',
+    289: 'Authentication Bypass by Alternate Name',
+    290: 'Authentication Bypass by Spoofing',
+    291: 'Reliance on IP Address for Authentication',
+    292: 'DEPRECATED: Trusting Self-reported DNS Name',
+    293: 'Using Referer Field for Authentication',
+    294: 'Authentication Bypass by Capture-replay',
+    295: 'Improper Certificate Validation',
+    296: 'Improper Following of a Certificates Chain of Trust',
+    297: 'Improper Validation of Certificate with Host Mismatch',
+    298: 'Improper Validation of Certificate Expiration',
+    299: 'Improper Check for Certificate Revocation',
+    300: 'Channel Accessible by Non-Endpoint',
+    301: 'Reflection Attack in an Authentication Protocol',
+    302: 'Authentication Bypass by Assumed-Immutable Data',
+    303: 'Incorrect Implementation of Authentication Algorithm',
+    304: 'Missing Critical Step in Authentication',
+    305: 'Authentication Bypass by Primary Weakness',
+    306: 'Missing Authentication for Critical Function',
+    307: 'Improper Restriction of Excessive Authentication Attempts',
+    308: 'Use of Single-factor Authentication',
+    309: 'Use of Password System for Primary Authentication',
+    311: 'Missing Encryption of Sensitive Data',
+    312: 'Cleartext Storage of Sensitive Information',
+    313: 'Cleartext Storage in a File or on Disk',
+    314: 'Cleartext Storage in the Registry',
+    315: 'Cleartext Storage of Sensitive Information in a Cookie',
+    316: 'Cleartext Storage of Sensitive Information in Memory',
+    317: 'Cleartext Storage of Sensitive Information in GUI',
+    318: 'Cleartext Storage of Sensitive Information in Executable',
+    319: 'Cleartext Transmission of Sensitive Information',
+    321: 'Use of Hard-coded Cryptographic Key',
+    322: 'Key Exchange without Entity Authentication',
+    323: 'Reusing a Nonce, Key Pair in Encryption',
+    324: 'Use of a Key Past its Expiration Date',
+    325: 'Missing Cryptographic Step',
+    326: 'Inadequate Encryption Strength',
+    327: 'Use of a Broken or Risky Cryptographic Algorithm',
+    328: 'Use of Weak Hash',
+    329: 'Generation of Predictable IV with CBC Mode',
+    330: 'Use of Insufficiently Random Values',
+    331: 'Insufficient Entropy',
+    332: 'Insufficient Entropy in PRNG',
+    333: 'Improper Handling of Insufficient Entropy in TRNG',
+    334: 'Small Space of Random Values',
+    335: 'Incorrect Usage of Seeds in Pseudo-Random Number Generator',
+    336: 'Same Seed in Pseudo-Random Number Generator',
+    337: 'Predictable Seed in Pseudo-Random Number Generator',
+    338: 'Use of Cryptographically Weak Pseudo-Random Number Generator',
+    339: 'Small Seed Space in PRNG',
+    340: 'Generation of Predictable Numbers or Identifiers',
+    341: 'Predictable from Observable State',
+    342: 'Predictable Exact Value from Previous Values',
+    343: 'Predictable Value Range from Previous Values',
+    344: 'Use of Invariant Value in Dynamically Changing Context',
+    345: 'Insufficient Verification of Data Authenticity',
+    346: 'Origin Validation Error',
+    347: 'Improper Verification of Cryptographic Signature',
+    348: 'Use of Less Trusted Source',
+    349: 'Acceptance of Extraneous Untrusted Data With Trusted Data',
+    350: 'Reliance on Reverse DNS Resolution for a Security-Critical Action',
+    351: 'Insufficient Type Distinction',
+    352: 'Cross-Site Request Forgery',
+    353: 'Missing Support for Integrity Check',
+    354: 'Improper Validation of Integrity Check Value',
+    356: 'Product UI does not Warn User of Unsafe Actions',
+    357: 'Insufficient UI Warning of Dangerous Operations',
+    358: 'Improperly Implemented Security Check for Standard',
+    359: 'Exposure of Private Personal Information to an Unauthorized Actor',
+    360: 'Trust of System Event Data',
+    362: 'Concurrent Execution using Shared Resource with Improper '
+         'Synchronization',
+    363: 'Race Condition Enabling Link Following',
+    364: 'Signal Handler Race Condition',
+    365: 'DEPRECATED: Race Condition in Switch',
+    366: 'Race Condition within a Thread',
+    367: 'Time-of-check Time-of-use',
+    368: 'Context Switching Race Condition',
+    369: 'Divide By Zero',
+    370: 'Missing Check for Certificate Revocation after Initial Check',
+    372: 'Incomplete Internal State Distinction',
+    373: 'DEPRECATED: State Synchronization Error',
+    374: 'Passing Mutable Objects to an Untrusted Method',
+    375: 'Returning a Mutable Object to an Untrusted Caller',
+    377: 'Insecure Temporary File',
+    378: 'Creation of Temporary File With Insecure Permissions',
+    379: 'Creation of Temporary File in Directory with Insecure Permissions',
+    382: 'J2EE Bad Practices: Use of System.exit',
+    383: 'J2EE Bad Practices: Direct Use of Threads',
+    384: 'Session Fixation',
+    385: 'Covert Timing Channel',
+    386: 'Symbolic Name not Mapping to Correct Object',
+    390: 'Detection of Error Condition Without Action',
+    391: 'Unchecked Error Condition',
+    392: 'Missing Report of Error Condition',
+    393: 'Return of Wrong Status Code',
+    394: 'Unexpected Status Code or Return Value',
+    395: 'Use of NullPointerException Catch to Detect NULL Pointer Dereference',
+    396: 'Declaration of Catch for Generic Exception',
+    397: 'Declaration of Throws for Generic Exception',
+    400: 'Uncontrolled Resource Consumption',
+    401: 'Missing Release of Memory after Effective Lifetime',
+    402: 'Transmission of Private Resources into a New Sphere',
+    403: 'Exposure of File Descriptor to Unintended Control Sphere',
+    404: 'Improper Resource Shutdown or Release',
+    405: 'Asymmetric Resource Consumption',
+    406: 'Insufficient Control of Network Message Volume',
+    407: 'Inefficient Algorithmic Complexity',
+    408: 'Incorrect Behavior Order: Early Amplification',
+    409: 'Improper Handling of Highly Compressed Data',
+    410: 'Insufficient Resource Pool',
+    412: 'Unrestricted Externally Accessible Lock',
+    413: 'Improper Resource Locking',
+    414: 'Missing Lock Check',
+    415: 'Double Free',
+    416: 'Use After Free',
+    419: 'Unprotected Primary Channel',
+    420: 'Unprotected Alternate Channel',
+    421: 'Race Condition During Access to Alternate Channel',
+    422: 'Unprotected Windows Messaging Channel',
+    423: 'DEPRECATED: Proxied Trusted Channel',
+    424: 'Improper Protection of Alternate Path',
+    425: 'Direct Request',
+    426: 'Untrusted Search Path',
+    427: 'Uncontrolled Search Path Element',
+    428: 'Unquoted Search Path or Element',
+    430: 'Deployment of Wrong Handler',
+    431: 'Missing Handler',
+    432: 'Dangerous Signal Handler not Disabled During Sensitive Operations',
+    433: 'Unparsed Raw Web Content Delivery',
+    434: 'Unrestricted Upload of File with Dangerous Type',
+    435: 'Improper Interaction Between Multiple Correctly-Behaving Entities',
+    436: 'Interpretation Conflict',
+    437: 'Incomplete Model of Endpoint Features',
+    439: 'Behavioral Change in New Version or Environment',
+    440: 'Expected Behavior Violation',
+    441: 'Unintended Proxy or Intermediary',
+    443: 'DEPRECATED: HTTP response splitting',
+    444: 'Inconsistent Interpretation of HTTP Requests',
+    446: 'UI Discrepancy for Security Feature',
+    447: 'Unimplemented or Unsupported Feature in UI',
+    448: 'Obsolete Feature in UI',
+    449: 'The UI Performs the Wrong Action',
+    450: 'Multiple Interpretations of UI Input',
+    451: 'User Interface',
+    453: 'Insecure Default Variable Initialization',
+    454: 'External Initialization of Trusted Variables or Data Stores',
+    455: 'Non-exit on Failed Initialization',
+    456: 'Missing Initialization of a Variable',
+    457: 'Use of Uninitialized Variable',
+    458: 'DEPRECATED: Incorrect Initialization',
+    459: 'Incomplete Cleanup',
+    460: 'Improper Cleanup on Thrown Exception',
+    462: 'Duplicate Key in Associative List',
+    463: 'Deletion of Data Structure Sentinel',
+    464: 'Addition of Data Structure Sentinel',
+    466: 'Return of Pointer Value Outside of Expected Range',
+    467: 'Use of sizeof',
+    468: 'Incorrect Pointer Scaling',
+    469: 'Use of Pointer Subtraction to Determine Size',
+    470: 'Use of Externally-Controlled Input to Select Classes or Code',
+    471: 'Modification of Assumed-Immutable Data',
+    472: 'External Control of Assumed-Immutable Web Parameter',
+    473: 'PHP External Variable Modification',
+    474: 'Use of Function with Inconsistent Implementations',
+    475: 'Undefined Behavior for Input to API',
+    476: 'NULL Pointer Dereference',
+    477: 'Use of Obsolete Function',
+    478: 'Missing Default Case in Multiple Condition Expression',
+    479: 'Signal Handler Use of a Non-reentrant Function',
+    480: 'Use of Incorrect Operator',
+    481: 'Assigning instead of Comparing',
+    482: 'Comparing instead of Assigning',
+    483: 'Incorrect Block Delimitation',
+    484: 'Omitted Break Statement in Switch',
+    486: 'Comparison of Classes by Name',
+    487: 'Reliance on Package-level Scope',
+    488: 'Exposure of Data Element to Wrong Session',
+    489: 'Active Debug Code',
+    491: 'Public cloneable',
+    492: 'Use of Inner Class Containing Sensitive Data',
+    493: 'Critical Public Variable Without Final Modifier',
+    494: 'Download of Code Without Integrity Check',
+    495: 'Private Data Structure Returned From A Public Method',
+    496: 'Public Data Assigned to Private Array-Typed Field',
+    497: 'Exposure of Sensitive System Information to an Unauthorized Control '
+         'Sphere',
+    498: 'Cloneable Class Containing Sensitive Information',
+    499: 'Serializable Class Containing Sensitive Data',
+    500: 'Public Static Field Not Marked Final',
+    501: 'Trust Boundary Violation',
+    502: 'Deserialization of Untrusted Data',
+    506: 'Embedded Malicious Code',
+    507: 'Trojan Horse',
+    508: 'Non-Replicating Malicious Code',
+    509: 'Replicating Malicious Code',
+    510: 'Trapdoor',
+    511: 'Logic/Time Bomb',
+    512: 'Spyware',
+    514: 'Covert Channel',
+    515: 'Covert Storage Channel',
+    516: 'DEPRECATED: Covert Timing Channel',
+    520: '.NET Misconfiguration: Use of Impersonation',
+    521: 'Weak Password Requirements',
+    522: 'Insufficiently Protected Credentials',
+    523: 'Unprotected Transport of Credentials',
+    524: 'Use of Cache Containing Sensitive Information',
+    525: 'Use of Web Browser Cache Containing Sensitive Information',
+    526: 'Cleartext Storage of Sensitive Information in an Environment '
+         'Variable',
+    527: 'Exposure of Version-Control Repository to an Unauthorized Control '
+         'Sphere',
+    528: 'Exposure of Core Dump File to an Unauthorized Control Sphere',
+    529: 'Exposure of Access Control List Files to an Unauthorized Control '
+         'Sphere',
+    530: 'Exposure of Backup File to an Unauthorized Control Sphere',
+    531: 'Inclusion of Sensitive Information in Test Code',
+    532: 'Insertion of Sensitive Information into Log File',
+    533: 'DEPRECATED: Information Exposure Through Server Log Files',
+    534: 'DEPRECATED: Information Exposure Through Debug Log Files',
+    535: 'Exposure of Information Through Shell Error Message',
+    536: 'Servlet Runtime Error Message Containing Sensitive Information',
+    537: 'Java Runtime Error Message Containing Sensitive Information',
+    538: 'Insertion of Sensitive Information into Externally-Accessible File or'
+         ' Directory',
+    539: 'Use of Persistent Cookies Containing Sensitive Information',
+    540: 'Inclusion of Sensitive Information in Source Code',
+    541: 'Inclusion of Sensitive Information in an Include File',
+    542: 'DEPRECATED: Information Exposure Through Cleanup Log Files',
+    543: 'Use of Singleton Pattern Without Synchronization in a Multithreaded '
+         'Context',
+    544: 'Missing Standardized Error Handling Mechanism',
+    545: 'DEPRECATED: Use of Dynamic Class Loading',
+    546: 'Suspicious Comment',
+    547: 'Use of Hard-coded, Security-relevant Constants',
+    548: 'Exposure of Information Through Directory Listing',
+    549: 'Missing Password Field Masking',
+    550: 'Server-generated Error Message Containing Sensitive Information',
+    551: 'Incorrect Behavior Order: Authorization Before Parsing and '
+         'Canonicalization',
+    552: 'Files or Directories Accessible to External Parties',
+    553: 'Command Shell in Externally Accessible Directory',
+    554: 'ASP.NET Misconfiguration: Not Using Input Validation Framework',
+    555: 'J2EE Misconfiguration: Plaintext Password in Configuration File',
+    556: 'ASP.NET Misconfiguration: Use of Identity Impersonation',
+    558: 'Use of getlogin',
+    560: 'Use of umask',
+    561: 'Dead Code',
+    562: 'Return of Stack Variable Address',
+    563: 'Assignment to Variable without Use',
+    564: 'SQL Injection: Hibernate',
+    565: 'Reliance on Cookies without Validation and Integrity Checking',
+    566: 'Authorization Bypass Through User-Controlled SQL Primary Key',
+    567: 'Unsynchronized Access to Shared Data in a Multithreaded Context',
+    568: 'finalize',
+    570: 'Expression is Always False',
+    571: 'Expression is Always True',
+    572: 'Call to Thread run',
+    573: 'Improper Following of Specification by Caller',
+    574: 'EJB Bad Practices: Use of Synchronization Primitives',
+    575: 'EJB Bad Practices: Use of AWT Swing',
+    576: 'EJB Bad Practices: Use of Java I/O',
+    577: 'EJB Bad Practices: Use of Sockets',
+    578: 'EJB Bad Practices: Use of Class Loader',
+    579: 'J2EE Bad Practices: Non-serializable Object Stored in Session',
+    580: 'clone',
+    581: 'Object Model Violation: Just One of Equals and Hashcode Defined',
+    582: 'Array Declared Public, Final, and Static',
+    583: 'finalize',
+    584: 'Return Inside Finally Block',
+    585: 'Empty Synchronized Block',
+    586: 'Explicit Call to Finalize',
+    587: 'Assignment of a Fixed Address to a Pointer',
+    588: 'Attempt to Access Child of a Non-structure Pointer',
+    589: 'Call to Non-ubiquitous API',
+    590: 'Free of Memory not on the Heap',
+    591: 'Sensitive Data Storage in Improperly Locked Memory',
+    592: 'DEPRECATED: Authentication Bypass Issues',
+    593: 'Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects '
+         'are Created',
+    594: 'J2EE Framework: Saving Unserializable Objects to Disk',
+    595: 'Comparison of Object References Instead of Object Contents',
+    596: 'DEPRECATED: Incorrect Semantic Object Comparison',
+    597: 'Use of Wrong Operator in String Comparison',
+    598: 'Use of GET Request Method With Sensitive Query Strings',
+    599: 'Missing Validation of OpenSSL Certificate',
+    600: 'Uncaught Exception in Servlet ',
+    601: 'URL Redirection to Untrusted Site',
+    602: 'Client-Side Enforcement of Server-Side Security',
+    603: 'Use of Client-Side Authentication',
+    605: 'Multiple Binds to the Same Port',
+    606: 'Unchecked Input for Loop Condition',
+    607: 'Public Static Final Field References Mutable Object',
+    608: 'Struts: Non-private Field in ActionForm Class',
+    609: 'Double-Checked Locking',
+    610: 'Externally Controlled Reference to a Resource in Another Sphere',
+    611: 'Improper Restriction of XML External Entity Reference',
+    612: 'Improper Authorization of Index Containing Sensitive Information',
+    613: 'Insufficient Session Expiration',
+    614: 'Sensitive Cookie in HTTPS Session Without Secure Attribute',
+    615: 'Inclusion of Sensitive Information in Source Code Comments',
+    616: 'Incomplete Identification of Uploaded File Variables',
+    617: 'Reachable Assertion',
+    618: 'Exposed Unsafe ActiveX Method',
+    619: 'Dangling Database Cursor',
+    620: 'Unverified Password Change',
+    621: 'Variable Extraction Error',
+    622: 'Improper Validation of Function Hook Arguments',
+    623: 'Unsafe ActiveX Control Marked Safe For Scripting',
+    624: 'Executable Regular Expression Error',
+    625: 'Permissive Regular Expression',
+    626: 'Null Byte Interaction Error',
+    627: 'Dynamic Variable Evaluation',
+    628: 'Function Call with Incorrectly Specified Arguments',
+    636: 'Not Failing Securely',
+    637: 'Unnecessary Complexity in Protection Mechanism',
+    638: 'Not Using Complete Mediation',
+    639: 'Authorization Bypass Through User-Controlled Key',
+    640: 'Weak Password Recovery Mechanism for Forgotten Password',
+    641: 'Improper Restriction of Names for Files and Other Resources',
+    642: 'External Control of Critical State Data',
+    643: 'Improper Neutralization of Data within XPath Expressions',
+    644: 'Improper Neutralization of HTTP Headers for Scripting Syntax',
+    645: 'Overly Restrictive Account Lockout Mechanism',
+    646: 'Reliance on File Name or Extension of Externally-Supplied File',
+    647: 'Use of Non-Canonical URL Paths for Authorization Decisions',
+    648: 'Incorrect Use of Privileged APIs',
+    649: 'Reliance on Obfuscation or Encryption of Security-Relevant Inputs '
+         'without Integrity Checking',
+    650: 'Trusting HTTP Permission Methods on the Server Side',
+    651: 'Exposure of WSDL File Containing Sensitive Information',
+    652: 'Improper Neutralization of Data within XQuery Expressions',
+    653: 'Improper Isolation or Compartmentalization',
+    654: 'Reliance on a Single Factor in a Security Decision',
+    655: 'Insufficient Psychological Acceptability',
+    656: 'Reliance on Security Through Obscurity',
+    657: 'Violation of Secure Design Principles',
+    662: 'Improper Synchronization',
+    663: 'Use of a Non-reentrant Function in a Concurrent Context',
+    664: 'Improper Control of a Resource Through its Lifetime',
+    665: 'Improper Initialization',
+    666: 'Operation on Resource in Wrong Phase of Lifetime',
+    667: 'Improper Locking',
+    668: 'Exposure of Resource to Wrong Sphere',
+    669: 'Incorrect Resource Transfer Between Spheres',
+    670: 'Always-Incorrect Control Flow Implementation',
+    671: 'Lack of Administrator Control over Security',
+    672: 'Operation on a Resource after Expiration or Release',
+    673: 'External Influence of Sphere Definition',
+    674: 'Uncontrolled Recursion',
+    675: 'Multiple Operations on Resource in Single-Operation Context',
+    676: 'Use of Potentially Dangerous Function',
+    680: 'Integer Overflow to Buffer Overflow',
+    681: 'Incorrect Conversion between Numeric Types',
+    682: 'Incorrect Calculation',
+    683: 'Function Call With Incorrect Order of Arguments',
+    684: 'Incorrect Provision of Specified Functionality',
+    685: 'Function Call With Incorrect Number of Arguments',
+    686: 'Function Call With Incorrect Argument Type',
+    687: 'Function Call With Incorrectly Specified Argument Value',
+    688: 'Function Call With Incorrect Variable or Reference as Argument',
+    689: 'Permission Race Condition During Resource Copy',
+    690: 'Unchecked Return Value to NULL Pointer Dereference',
+    691: 'Insufficient Control Flow Management',
+    692: 'Incomplete Denylist to Cross-Site Scripting',
+    693: 'Protection Mechanism Failure',
+    694: 'Use of Multiple Resources with Duplicate Identifier',
+    695: 'Use of Low-Level Functionality',
+    696: 'Incorrect Behavior Order',
+    697: 'Incorrect Comparison',
+    698: 'Execution After Redirect',
+    703: 'Improper Check or Handling of Exceptional Conditions',
+    704: 'Incorrect Type Conversion or Cast',
+    705: 'Incorrect Control Flow Scoping',
+    706: 'Use of Incorrectly-Resolved Name or Reference',
+    707: 'Improper Neutralization',
+    708: 'Incorrect Ownership Assignment',
+    710: 'Improper Adherence to Coding Standards',
+    732: 'Incorrect Permission Assignment for Critical Resource',
+    733: 'Compiler Optimization Removal or Modification of Security-critical '
+         'Code',
+    749: 'Exposed Dangerous Method or Function',
+    754: 'Improper Check for Unusual or Exceptional Conditions',
+    755: 'Improper Handling of Exceptional Conditions',
+    756: 'Missing Custom Error Page',
+    757: 'Selection of Less-Secure Algorithm During Negotiation',
+    758: 'Reliance on Undefined, Unspecified, or Implementation-Defined '
+         'Behavior',
+    759: 'Use of a One-Way Hash without a Salt',
+    760: 'Use of a One-Way Hash with a Predictable Salt',
+    761: 'Free of Pointer not at Start of Buffer',
+    762: 'Mismatched Memory Management Routines',
+    763: 'Release of Invalid Pointer or Reference',
+    764: 'Multiple Locks of a Critical Resource',
+    765: 'Multiple Unlocks of a Critical Resource',
+    766: 'Critical Data Element Declared Public',
+    767: 'Access to Critical Private Variable via Public Method',
+    768: 'Incorrect Short Circuit Evaluation',
+    769: 'DEPRECATED: Uncontrolled File Descriptor Consumption',
+    770: 'Allocation of Resources Without Limits or Throttling',
+    771: 'Missing Reference to Active Allocated Resource',
+    772: 'Missing Release of Resource after Effective Lifetime',
+    773: 'Missing Reference to Active File Descriptor or Handle',
+    774: 'Allocation of File Descriptors or Handles Without Limits or '
+         'Throttling',
+    775: 'Missing Release of File Descriptor or Handle after Effective '
+         'Lifetime',
+    776: 'Improper Restriction of Recursive Entity References in DTDs',
+    777: 'Regular Expression without Anchors',
+    778: 'Insufficient Logging',
+    779: 'Logging of Excessive Data',
+    780: 'Use of RSA Algorithm without OAEP',
+    781: 'Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control '
+         'Code',
+    782: 'Exposed IOCTL with Insufficient Access Control',
+    783: 'Operator Precedence Logic Error',
+    784: 'Reliance on Cookies without Validation and Integrity Checking in a '
+         'Security Decision',
+    785: 'Use of Path Manipulation Function without Maximum-sized Buffer',
+    786: 'Access of Memory Location Before Start of Buffer',
+    787: 'Out-of-bounds Write',
+    788: 'Access of Memory Location After End of Buffer',
+    789: 'Memory Allocation with Excessive Size Value',
+    790: 'Improper Filtering of Special Elements',
+    791: 'Incomplete Filtering of Special Elements',
+    792: 'Incomplete Filtering of One or More Instances of Special Elements',
+    793: 'Only Filtering One Instance of a Special Element',
+    794: 'Incomplete Filtering of Multiple Instances of Special Elements',
+    795: 'Only Filtering Special Elements at a Specified Location',
+    796: 'Only Filtering Special Elements Relative to a Marker',
+    797: 'Only Filtering Special Elements at an Absolute Position',
+    798: 'Use of Hard-coded Credentials',
+    799: 'Improper Control of Interaction Frequency',
+    804: 'Guessable CAPTCHA',
+    805: 'Buffer Access with Incorrect Length Value',
+    806: 'Buffer Access Using Size of Source Buffer',
+    807: 'Reliance on Untrusted Inputs in a Security Decision',
+    820: 'Missing Synchronization',
+    821: 'Incorrect Synchronization',
+    822: 'Untrusted Pointer Dereference',
+    823: 'Use of Out-of-range Pointer Offset',
+    824: 'Access of Uninitialized Pointer',
+    825: 'Expired Pointer Dereference',
+    826: 'Premature Release of Resource During Expected Lifetime',
+    827: 'Improper Control of Document Type Definition',
+    828: 'Signal Handler with Functionality that is not Asynchronous-Safe',
+    829: 'Inclusion of Functionality from Untrusted Control Sphere',
+    830: 'Inclusion of Web Functionality from an Untrusted Source',
+    831: 'Signal Handler Function Associated with Multiple Signals',
+    832: 'Unlock of a Resource that is not Locked',
+    833: 'Deadlock',
+    834: 'Excessive Iteration',
+    835: 'Loop with Unreachable Exit Condition',
+    836: 'Use of Password Hash Instead of Password for Authentication',
+    837: 'Improper Enforcement of a Single, Unique Action',
+    838: 'Inappropriate Encoding for Output Context',
+    839: 'Numeric Range Comparison Without Minimum Check',
+    841: 'Improper Enforcement of Behavioral Workflow',
+    842: 'Placement of User into Incorrect Group',
+    843: 'Access of Resource Using Incompatible Type',
+    862: 'Missing Authorization',
+    863: 'Incorrect Authorization',
+    908: 'Use of Uninitialized Resource',
+    909: 'Missing Initialization of Resource',
+    910: 'Use of Expired File Descriptor',
+    911: 'Improper Update of Reference Count',
+    912: 'Hidden Functionality',
+    913: 'Improper Control of Dynamically-Managed Code Resources',
+    914: 'Improper Control of Dynamically-Identified Variables',
+    915: 'Improperly Controlled Modification of Dynamically-Determined Object '
+         'Attributes',
+    916: 'Use of Password Hash With Insufficient Computational Effort',
+    917: 'Improper Neutralization of Special Elements used in an Expression '
+         'Language Statement',
+    918: 'Server-Side Request Forgery',
+    920: 'Improper Restriction of Power Consumption',
+    921: 'Storage of Sensitive Data in a Mechanism without Access Control',
+    922: 'Insecure Storage of Sensitive Information',
+    923: 'Improper Restriction of Communication Channel to Intended Endpoints',
+    924: 'Improper Enforcement of Message Integrity During Transmission in a '
+         'Communication Channel',
+    925: 'Improper Verification of Intent by Broadcast Receiver',
+    926: 'Improper Export of Android Application Components',
+    927: 'Use of Implicit Intent for Sensitive Communication',
+    939: 'Improper Authorization in Handler for Custom URL Scheme',
+    940: 'Improper Verification of Source of a Communication Channel',
+    941: 'Incorrectly Specified Destination in a Communication Channel',
+    942: 'Permissive Cross-domain Policy with Untrusted Domains',
+    943: 'Improper Neutralization of Special Elements in Data Query Logic',
+    1004: 'Sensitive Cookie Without HttpOnly Flag',
+    1007: 'Insufficient Visual Distinction of Homoglyphs Presented to User',
+    1021: 'Improper Restriction of Rendered UI Layers or Frames',
+    1022: 'Use of Web Link to Untrusted Target with window.opener Access',
+    1023: 'Incomplete Comparison with Missing Factors',
+    1024: 'Comparison of Incompatible Types',
+    1025: 'Comparison Using Wrong Factors',
+    1037: 'Processor Optimization Removal or Modification of '
+          'Security-critical Code',
+    1038: 'Insecure Automated Optimizations',
+    1039: 'Automated Recognition Mechanism with Inadequate Detection or '
+          'Handling of Adversarial Input Perturbations',
+    1041: 'Use of Redundant Code',
+    1042: 'Static Member Data Element outside of a Singleton Class Element',
+    1043: 'Data Element Aggregating an Excessively Large Number of '
+          'Non-Primitive Elements',
+    1044: 'Architecture with Number of Horizontal Layers Outside of Expected '
+          'Range',
+    1045: 'Parent Class with a Virtual Destructor and a Child Class without a '
+          'Virtual Destructor',
+    1046: 'Creation of Immutable Text Using String Concatenation',
+    1047: 'Modules with Circular Dependencies',
+    1048: 'Invokable Control Element with Large Number of Outward Calls',
+    1049: 'Excessive Data Query Operations in a Large Data Table',
+    1050: 'Excessive Platform Resource Consumption within a Loop',
+    1051: 'Initialization with Hard-Coded Network Resource Configuration Data',
+    1052: 'Excessive Use of Hard-Coded Literals in Initialization',
+    1053: 'Missing Documentation for Design',
+    1054: 'Invocation of a Control Element at an Unnecessarily Deep '
+          'Horizontal Layer',
+    1055: 'Multiple Inheritance from Concrete Classes',
+    1056: 'Invokable Control Element with Variadic Parameters',
+    1057: 'Data Access Operations Outside of Expected Data Manager Component',
+    1058: 'Invokable Control Element in Multi-Thread Context with non-Final '
+          'Static Storable or Member Element',
+    1059: 'Insufficient Technical Documentation',
+    1060: 'Excessive Number of Inefficient Server-Side Data Accesses',
+    1061: 'Insufficient Encapsulation',
+    1062: 'Parent Class with References to Child Class',
+    1063: 'Creation of Class Instance within a Static Code Block',
+    1064: 'Invokable Control Element with Signature Containing an Excessive '
+          'Number of Parameters',
+    1065: 'Runtime Resource Management Control Element in a Component Built '
+          'to Run on Application Servers',
+    1066: 'Missing Serialization Control Element',
+    1067: 'Excessive Execution of Sequential Searches of Data Resource',
+    1068: 'Inconsistency Between Implementation and Documented Design',
+    1069: 'Empty Exception Block',
+    1070: 'Serializable Data Element Containing non-Serializable Item Elements',
+    1071: 'Empty Code Block',
+    1072: 'Data Resource Access without Use of Connection Pooling',
+    1073: 'Non-SQL Invokable Control Element with Excessive Number of Data '
+          'Resource Accesses',
+    1074: 'Class with Excessively Deep Inheritance',
+    1075: 'Unconditional Control Flow Transfer outside of Switch Block',
+    1076: 'Insufficient Adherence to Expected Conventions',
+    1077: 'Floating Point Comparison with Incorrect Operator',
+    1078: 'Inappropriate Source Code Style or Formatting',
+    1079: 'Parent Class without Virtual Destructor Method',
+    1080: 'Source Code File with Excessive Number of Lines of Code',
+    1082: 'Class Instance Self Destruction Control Element',
+    1083: 'Data Access from Outside Expected Data Manager Component',
+    1084: 'Invokable Control Element with Excessive File or Data Access '
+          'Operations',
+    1085: 'Invokable Control Element with Excessive Volume of Commented-out '
+          'Code',
+    1086: 'Class with Excessive Number of Child Classes',
+    1087: 'Class with Virtual Method without a Virtual Destructor',
+    1088: 'Synchronous Access of Remote Resource without Timeout',
+    1089: 'Large Data Table with Excessive Number of Indices',
+    1090: 'Method Containing Access of a Member Element from Another Class',
+    1091: 'Use of Object without Invoking Destructor Method',
+    1092: 'Use of Same Invokable Control Element in Multiple Architectural '
+          'Layers',
+    1093: 'Excessively Complex Data Representation',
+    1094: 'Excessive Index Range Scan for a Data Resource',
+    1095: 'Loop Condition Value Update within the Loop',
+    1096: 'Singleton Class Instance Creation without Proper Locking or '
+          'Synchronization',
+    1097: 'Persistent Storable Data Element without Associated Comparison '
+          'Control Element',
+    1098: 'Data Element containing Pointer Item without Proper Copy Control '
+          'Element',
+    1099: 'Inconsistent Naming Conventions for Identifiers',
+    1100: 'Insufficient Isolation of System-Dependent Functions',
+    1101: 'Reliance on Runtime Component in Generated Code',
+    1102: 'Reliance on Machine-Dependent Data Representation',
+    1103: 'Use of Platform-Dependent Third Party Components',
+    1104: 'Use of Unmaintained Third Party Components',
+    1105: 'Insufficient Encapsulation of Machine-Dependent Functionality',
+    1106: 'Insufficient Use of Symbolic Constants',
+    1107: 'Insufficient Isolation of Symbolic Constant Definitions',
+    1108: 'Excessive Reliance on Global Variables',
+    1109: 'Use of Same Variable for Multiple Purposes',
+    1110: 'Incomplete Design Documentation',
+    1111: 'Incomplete I/O Documentation',
+    1112: 'Incomplete Documentation of Program Execution',
+    1113: 'Inappropriate Comment Style',
+    1114: 'Inappropriate Whitespace Style',
+    1115: 'Source Code Element without Standard Prologue',
+    1116: 'Inaccurate Comments',
+    1117: 'Callable with Insufficient Behavioral Summary',
+    1118: 'Insufficient Documentation of Error Handling Techniques',
+    1119: 'Excessive Use of Unconditional Branching',
+    1120: 'Excessive Code Complexity',
+    1121: 'Excessive McCabe Cyclomatic Complexity',
+    1122: 'Excessive Halstead Complexity',
+    1123: 'Excessive Use of Self-Modifying Code',
+    1124: 'Excessively Deep Nesting',
+    1125: 'Excessive Attack Surface',
+    1126: 'Declaration of Variable with Unnecessarily Wide Scope',
+    1127: 'Compilation with Insufficient Warnings or Errors',
+    1164: 'Irrelevant Code',
+    1173: 'Improper Use of Validation Framework',
+    1174: 'ASP.NET Misconfiguration: Improper Model Validation',
+    1176: 'Inefficient CPU Computation',
+    1177: 'Use of Prohibited Code',
+    1187: 'DEPRECATED: Use of Uninitialized Resource',
+    1188: 'Insecure Default Initialization of Resource',
+    1189: 'Improper Isolation of Shared Resources on System-on-a-Chip',
+    1190: 'DMA Device Enabled Too Early in Boot Phase',
+    1191: 'On-Chip Debug and Test Interface With Improper Access Control',
+    1192: 'System-on-Chip',
+    1193: 'Power-On of Untrusted Execution Core Before Enabling Fabric Access '
+          'Control',
+    1204: 'Generation of Weak Initialization Vector',
+    1209: 'Failure to Disable Reserved Bits',
+    1220: 'Insufficient Granularity of Access Control',
+    1221: 'Incorrect Register Defaults or Module Parameters',
+    1222: 'Insufficient Granularity of Address Regions Protected by Register '
+          'Locks',
+    1223: 'Race Condition for Write-Once Attributes',
+    1224: 'Improper Restriction of Write-Once Bit Fields',
+    1229: 'Creation of Emergent Resource',
+    1230: 'Exposure of Sensitive Information Through Metadata',
+    1231: 'Improper Prevention of Lock Bit Modification',
+    1232: 'Improper Lock Behavior After Power State Transition',
+    1233: 'Security-Sensitive Hardware Controls with Missing Lock Bit '
+          'Protection',
+    1234: 'Hardware Internal or Debug Modes Allow Override of Locks',
+    1235: 'Incorrect Use of Autoboxing and Unboxing for Performance Critical '
+          'Operations',
+    1236: 'Improper Neutralization of Formula Elements in a CSV File',
+    1239: 'Improper Zeroization of Hardware Register',
+    1240: 'Use of a Cryptographic Primitive with a Risky Implementation',
+    1241: 'Use of Predictable Algorithm in Random Number Generator',
+    1242: 'Inclusion of Undocumented Features or Chicken Bits',
+    1243: 'Sensitive Non-Volatile Information Not Protected During Debug',
+    1244: 'Internal Asset Exposed to Unsafe Debug Access Level or State',
+    1245: 'Improper Finite State Machines',
+    1246: 'Improper Write Handling in Limited-write Non-Volatile Memories',
+    1247: 'Improper Protection Against Voltage and Clock Glitches',
+    1248: 'Semiconductor Defects in Hardware Logic with Security-Sensitive '
+          'Implications',
+    1249: 'Application-Level Admin Tool with Inconsistent View of Underlying '
+          'Operating System',
+    1250: 'Improper Preservation of Consistency Between Independent '
+          'Representations of Shared State',
+    1251: 'Mirrored Regions with Different Values',
+    1252: 'CPU Hardware Not Configured to Support Exclusivity of Write and '
+          'Execute Operations',
+    1253: 'Incorrect Selection of Fuse Values',
+    1254: 'Incorrect Comparison Logic Granularity',
+    1255: 'Comparison Logic is Vulnerable to Power Side-Channel Attacks',
+    1256: 'Improper Restriction of Software Interfaces to Hardware Features',
+    1257: 'Improper Access Control Applied to Mirrored or Aliased Memory '
+          'Regions',
+    1258: 'Exposure of Sensitive System Information Due to Uncleared Debug '
+          'Information',
+    1259: 'Improper Restriction of Security Token Assignment',
+    1260: 'Improper Handling of Overlap Between Protected Memory Ranges',
+    1261: 'Improper Handling of Single Event Upsets',
+    1262: 'Improper Access Control for Register Interface',
+    1263: 'Improper Physical Access Control',
+    1264: 'Hardware Logic with Insecure De-Synchronization between Control and '
+          'Data Channels',
+    1265: 'Unintended Reentrant Invocation of Non-reentrant Code Via Nested '
+          'Calls',
+    1266: 'Improper Scrubbing of Sensitive Data from Decommissioned Device',
+    1267: 'Policy Uses Obsolete Encoding',
+    1268: 'Policy Privileges are not Assigned Consistently Between Control and '
+          'Data Agents',
+    1269: 'Product Released in Non-Release Configuration',
+    1270: 'Generation of Incorrect Security Tokens',
+    1271: 'Uninitialized Value on Reset for Registers Holding Security '
+          'Settings',
+    1272: 'Sensitive Information Uncleared Before Debug/Power State Transition',
+    1273: 'Device Unlock Credential Sharing',
+    1274: 'Improper Access Control for Volatile Memory Containing Boot Code',
+    1275: 'Sensitive Cookie with Improper SameSite Attribute',
+    1276: 'Hardware Child Block Incorrectly Connected to Parent System',
+    1277: 'Firmware Not Updateable',
+    1278: 'Missing Protection Against Hardware Reverse Engineering Using '
+          'Integrated Circuit',
+    1279: 'Cryptographic Operations are run Before Supporting Units are Ready',
+    1280: 'Access Control Check Implemented After Asset is Accessed',
+    1281: 'Sequence of Processor Instructions Leads to Unexpected Behavior',
+    1282: 'Assumed-Immutable Data is Stored in Writable Memory',
+    1283: 'Mutable Attestation or Measurement Reporting Data',
+    1284: 'Improper Validation of Specified Quantity in Input',
+    1285: 'Improper Validation of Specified Index, Position, or Offset in '
+          'Input',
+    1286: 'Improper Validation of Syntactic Correctness of Input',
+    1287: 'Improper Validation of Specified Type of Input',
+    1288: 'Improper Validation of Consistency within Input',
+    1289: 'Improper Validation of Unsafe Equivalence in Input',
+    1290: 'Incorrect Decoding of Security Identifiers ',
+    1291: 'Public Key Re-Use for Signing both Debug and Production Code',
+    1292: 'Incorrect Conversion of Security Identifiers',
+    1293: 'Missing Source Correlation of Multiple Independent Data',
+    1294: 'Insecure Security Identifier Mechanism',
+    1295: 'Debug Messages Revealing Unnecessary Information',
+    1296: 'Incorrect Chaining or Granularity of Debug Components',
+    1297: 'Unprotected Confidential Information on Device is Accessible by '
+          'OSAT Vendors',
+    1298: 'Hardware Logic Contains Race Conditions',
+    1299: 'Missing Protection Mechanism for Alternate Hardware Interface',
+    1300: 'Improper Protection of Physical Side Channels',
+    1301: 'Insufficient or Incomplete Data Removal within Hardware Component',
+    1302: 'Missing Security Identifier',
+    1303: 'Non-Transparent Sharing of Microarchitectural Resources',
+    1304: 'Improperly Preserved Integrity of Hardware Configuration State '
+          'During a Power Save/Restore Operation',
+    1310: 'Missing Ability to Patch ROM Code',
+    1311: 'Improper Translation of Security Attributes by Fabric Bridge',
+    1312: 'Missing Protection for Mirrored Regions in On-Chip Fabric Firewall',
+    1313: 'Hardware Allows Activation of Test or Debug Logic at Runtime',
+    1314: 'Missing Write Protection for Parametric Data Values',
+    1315: 'Improper Setting of Bus Controlling Capability in Fabric End-point',
+    1316: 'Fabric-Address Map Allows Programming of Unwarranted Overlaps of '
+          'Protected and Unprotected Ranges',
+    1317: 'Improper Access Control in Fabric Bridge',
+    1318: 'Missing Support for Security Features in On-chip Fabrics or Buses',
+    1319: 'Improper Protection against Electromagnetic Fault Injection',
+    1320: 'Improper Protection for Outbound Error Messages and Alert Signals',
+    1321: 'Improperly Controlled Modification of Object Prototype Attributes',
+    1322: 'Use of Blocking Code in Single-threaded, Non-blocking Context',
+    1323: 'Improper Management of Sensitive Trace Data',
+    1324: 'DEPRECATED: Sensitive Information Accessible by Physical Probing '
+          'of JTAG Interface',
+    1325: 'Improperly Controlled Sequential Memory Allocation',
+    1326: 'Missing Immutable Root of Trust in Hardware',
+    1327: 'Binding to an Unrestricted IP Address',
+    1328: 'Security Version Number Mutable to Older Versions',
+    1329: 'Reliance on Component That is Not Updateable',
+    1330: 'Remanent Data Readable after Memory Erase',
+    1331: 'Improper Isolation of Shared Resources in Network On Chip',
+    1332: 'Improper Handling of Faults that Lead to Instruction Skips',
+    1333: 'Inefficient Regular Expression Complexity',
+    1334: 'Unauthorized Error Injection Can Degrade Hardware Redundancy',
+    1335: 'Incorrect Bitwise Shift of Integer',
+    1336: 'Improper Neutralization of Special Elements Used in a Template '
+          'Engine',
+    1338: 'Improper Protections Against Hardware Overheating',
+    1339: 'Insufficient Precision or Accuracy of a Real Number',
+    1341: 'Multiple Releases of Same Resource or Handle',
+    1342: 'Information Exposure through Microarchitectural State after '
+          'Transient Execution',
+    1351: 'Improper Handling of Hardware Behavior in Exceptionally Cold '
+          'Environments',
+    1357: 'Reliance on Insufficiently Trustworthy Component',
+    1384: 'Improper Handling of Physical or Environmental Conditions',
+    1385: 'Missing Origin Validation in WebSockets',
+    1386: 'Insecure Operation on Windows Junction / Mount Point',
+    1389: 'Incorrect Parsing of Numbers with Different Radices',
+    1390: 'Weak Authentication',
+    1391: 'Use of Weak Credentials',
+    1392: 'Use of Default Credentials',
+    1393: 'Use of Default Password',
+    1394: 'Use of Default Cryptographic Key',
+    1395: 'Dependency on Vulnerable Third-Party Component'
 }
 
 TOML_TEMPLATE = {
@@ -1110,7 +1066,7 @@ TOML_TEMPLATE = {
     },
 }
 
-ref_map = {
+REF_MAP = {
     r"(?P<org>[^\s./]+).(?:com|org)/(?:[\S]+)?/(?P<id>("
     r"?:ghsa|ntap|rhsa|rhba|zdi|dsa|cisco|intel)-?[\w\d\-:]+)": "Advisory",
     r"cve-[0-9]{4,}-[0-9]{4,}$": "CVE Record",
@@ -1141,226 +1097,210 @@ ref_map = {
     r"bitbucket.org/[^\s/]+/[^\s/]+/wiki/": "Bitbucket Wiki Entry",
     r"https://vuldb.com/\?id.\d+": "VulDB Entry",
 }
-sorted_ref_map = dict(
-    sorted(ref_map.items(), key=lambda x: len(x[0]), reverse=True)
+SORTED_REF_MAP = dict(
+    sorted(REF_MAP.items(), key=lambda x: len(x[0]), reverse=True)
 )
 
-compiled_patterns = {
+COMPILED_REF_PATTERNS = {
     re.compile(pattern, re.IGNORECASE): value
-    for pattern, value in sorted_ref_map.items()
+    for pattern, value in SORTED_REF_MAP.items()
 }
 
+PURL_REGEX = re.compile(
+    r"(?P<pkg>pkg:([^/@?]+)/([^/@?]+)/?(?:[^/@?]+)?)@(?P<version>\w+(?:"
+    r"\.\w+\.)?(?:\w+\.?)?(?:\w+)?)(?P<type>\?type=\w+)?",
+    re.IGNORECASE,
+)
 
-class CsafOccurence:
-    def __init__(self, res):
-        self.cve = res["id"]
-        [self.cwe, self.notes] = parse_cwe(res["problem_type"])
-        self.score = res["cvss_score"]
-        self.cvss_v3 = parse_cvss(res)
-        self.package_issue = res["package_issue"]
-        [
-            self.pkg,
-            self.product_status,
-            self.vrange,
-            self.search_string,
-        ] = get_product_status(res["package_issue"], res["matched_by"])
-        self.description = (
-            res["short_description"]
-            .replace("\\n", " ")
-            .replace("\\t", " ")
-            .replace("\n", " ")
-            .replace("\t", " ")
-        )
-        self.references = res["related_urls"]
-        self.type = (res["type"],)
-        self.severity = (
-            res["severity"] if (
-            res["severity"] in ["CRITICAL", "HIGH", "MEDIUM", "LOW", "NONE"]) else (
-            "UNKNOWN")
-        )
-        self.orig_date = res["source_orig_time"] or None
-        self.update_date = res["source_update_time"] or None
-
-    def to_dict(self):
-        vuln = {}
-        if self.cve.startswith("CVE"):
-            vuln["cve"] = self.cve
-        vuln["cwe"] = self.cwe
-        vuln["discovery_date"] = str(self.orig_date) or str(self.update_date)
-        vuln["product_status"] = self.product_status
-        [ids, vuln["references"]] = format_references(self.references)
-        vuln["ids"] = ids
-        if self.cvss_v3:
-            vuln["scores"] = [{"cvss_v3": self.cvss_v3, "products": [self.pkg]}]
-        self.notes.append(
-            {
-                "category": "general",
-                "text": self.description,
-                "details": "Vulnerability Description",
-            }
-        )
-        vuln["notes"] = self.notes
-        return vuln
+ISSUES_REGEX = re.compile(
+    r"(?P<host>github|bitbucket|chromium)(?:.com|.org)/(?P<owner>["
+    r"\w\-.]+)/(?P<repo>[\w\-.]+)/issues/(?:detail\?id=)?(?P<id>\d+)",
+    re.IGNORECASE,
+)
+ADVISORY_REGEX = re.compile(
+    r"(?P<org>[^\s/.]+).(?:com|org)/(?:\S+/)*/?(?P<id>[\w\-:]+)",
+    re.IGNORECASE,
+)
+BUGZILLA_REGEX = re.compile(
+    r"(?<=bugzilla.)(?P<owner>\S+)\.\w{3}/show_bug.cgi\?id=(?P<id>\S+)",
+    re.IGNORECASE,
+)
+USN_REGEX = re.compile(
+    r"(?<=usn.ubuntu.com/)[\d\-]+|(?<=ubuntu.com/security/notices/USN-)"
+    r"[\d\-]+",
+    re.IGNORECASE,
+)
 
 
-def get_product_status(issue, matched_by):
+def vdr_to_csaf(res):
     """
-    Generates the product status based on the given response and package.
+    Processes a vulnerability from the VDR format to the CSAF format.
 
-    Args:
-        issue (dict): The response dictionary of information about the product.
-        matched_by (str): The location data
 
-    Returns: dict: A dictionary containing the product status. The keys
-    represent different statuses, while the values represent the corresponding
-    locations. If the product has a fixed location, the key "fixed" will be
-    present with the fixed location as its value. If the product has an affected
-    location, the key "known_affected" will be present with the affected
-    location as its value.
+    :param res: The metadata for a single vulnerability.
+    :type res: dict
 
+    :return: The processed vulnerability in the CSAF format.
+    :rtype: dict
     """
-    product_status = {}
-    pkg = matched_by.split("|")
-    version_range = None
-    search_string = None
-    if len(pkg) == 3:
-        pkg = matched_by.split("|")[1]
-        search_string = pkg
-    elif len(pkg) == 4:
-        pkg = matched_by.split("|")[2]
-        search_string = f"{matched_by.split('|')[1]}/{pkg}"
-    if issue.get("fixed_location"):
-        product_status["fixed"] = [f"{pkg}:{issue.get('fixed_location')}"]
-    if issue.get("affected_location"):
-        try:
-            loc_dict = issue.get("affected_location")
-            version_range = loc_dict.get("version")
-            product_status["known_affected"] = [
-                f'{loc_dict.get("package")}:{version_range}'
-            ]
-        except json.JSONDecodeError:
-            logging.warning("Invalid JSON string for affected_location")
-    return pkg, product_status, version_range, search_string
+    cve = res.get("id", "")
+    acknowledgements = get_acknowledgements(res.get("source"))
+    pkgs = [i.get("ref") for i in res.get("affects")]
+    cwe, notes = parse_cwe(res.get("cwes"))
+    product_status = get_product_status(res.get("affects"))
+    cvss_v3 = parse_cvss(res.get("properties"))
+    description = (
+        res["description"]
+        .replace("\n", " ")
+        .replace("\t", " ")
+        .replace("\n", " ")
+        .replace("\t", " ")
+    )
+    ids, references = format_references(res.get("advisories"))
+    orig_date = res.get("published")
+    update_date = res.get("updated")
+    vuln = {}
+    if cve.startswith("CVE"):
+        vuln["cve"] = cve
+    vuln["cwe"] = cwe
+    vuln["acknowledgements"] = acknowledgements
+    vuln["discovery_date"] = str(orig_date) or str(update_date)
+    vuln["product_status"] = product_status
+    vuln["references"] = references
+    vuln["ids"] = ids
+    vuln["scores"] = [{"cvss_v3": cvss_v3, "products": pkgs}]
+    notes.append(
+        {
+            "category": "general",
+            "text": description,
+            "details": "Vulnerability Description",
+        }
+    )
+    vuln["notes"] = notes
+
+    return vuln
+
+
+def get_acknowledgements(source):
+    """
+    Generates the acknowledgements from the source data information
+    :param source: A dictionary with the source information
+    :type source: dict
+
+    :return: A dictionary containing the acknowledgements
+    :rtype: dict or None
+    """
+    if not source.get("name"):
+        return None
+
+    return {
+        "organization": source["name"],
+        "urls": [source["url"]]
+    }
+
+
+def get_product_status(affects):
+    """
+    Generates the product status
+
+    :param affects: List with the version information in a dict
+    :type affects: list
+
+    :return: A dictionary containing the product status
+    :rtype: dict
+    """
+    known_affected = []
+    fixed = []
+    for i in affects:
+        if match := PURL_REGEX.match(i.get("ref")):
+            ppkg = match.group("pkg")
+            ptype = match.group("type") or ""
+        else:
+            LOG.debug("Invalid PURL: %s", i.get("ref"))
+            continue
+        for v in i.get("versions"):
+            if v["status"] == "affected":
+                known_affected.append(i.get("ref"))
+            elif v["status"] == "unaffected":
+                fixed.append(f"{ppkg}@" + v["version"] + ptype)
+    return {"known_affected": known_affected, "fixed": fixed}
 
 
 def parse_cwe(cwe):
+    """
+    Takes a list of CWE numbers and returns a single CSAF CWE entry, with any
+    additional CWEs returned in notes (CSAF 2.0 only allows one CWE).
+
+    :param cwe: A list of CWE numbers
+    :type cwe: list
+
+    :return: A single CSAF CWE entry (dict) and notes (list)
+    :rtype: tuple
+    """
     fmt_cwe = None
     new_notes = []
 
-    if not cwe or cwe in ["UNKNOWN", [], "[]"]:
+    if len(cwe) == 0:
         return fmt_cwe, new_notes
 
-    cwe_ids = re.findall(r"CWE-[1-9]\d{0,5}", cwe)
-    for i, cweid in enumerate(cwe_ids):
-        cwe_name = CWE_MAP.get(cweid, "UNABLE TO LOCATE CWE NAME")
+    for i, cwe_id in enumerate(cwe):
+        cwe_name = CWE_MAP.get(cwe_id, "UNABLE TO LOCATE CWE NAME")
         if not cwe_name:
             LOG.warning(
                 "We couldn't locate the name of the CWE with the following "
                 "id: %s. Help us out by reporting the id at "
-                "https://github.com/owasp-dep-scan/dep-scan/issues.",
-                cweid,
-            )
+                "https://github.com/owasp-dep-scan/dep-scan/issues.", i, )
         if i == 0:
-            fmt_cwe = {
-                "id": cweid,
-                "name": cwe_name,
-            }
-        # CSAF 2.0 only allows a single CWE per vulnerability, so we add
-        # any additional CWEs to a note entry.
+            fmt_cwe = {"id": str(cwe_id), "name": cwe_name, }
         else:
             new_notes.append(
-                {
-                    "title": f"Additional CWE: {cweid}",
-                    "audience": "developers",
-                    "category": "other",
-                    "text": cwe_name,
-                }
-            )
+                {"title": f"Additional CWE: {cwe_id}", "audience": "developers",
+                    "category": "other", "text": cwe_name, })
 
     return fmt_cwe, new_notes
 
 
-def parse_cvss(res):
+def parse_cvss(props):
     """
-    Parses the CVSS information from the given response.
+    Parses the CVSS information from pkg_vulnerabilities
 
-    Parameters:
-        res (dict): The response containing the CVSS information.
+    :param props: The list of properties for the vulnerability
+    :type props: list
 
-    Returns:
-        dict or None: The parsed CVSS information as a dictionary, or None if
-        the CVSS vector string is empty as it is required for cvss v3.
-            The dictionary contains the following keys:
-                - baseScore (float): The base score of the CVSS.
-                - attackVector (str): The attack vector of the CVSS.
-                - privilegesRequired (str): Privileges required for the CVSS.
-                - userInteraction (str): User interaction required for the CVSS.
-                - scope (str): The scope of the CVSS.
-                - impactScore (str): The impact score of the CVSS.
-                - baseSeverity (str): The base severity of the CVSS.
-                - version (str): The version of the CVSS.
-                - vectorString (str): The vector string of the CVSS.
-            If the vector string or base score are missing, or the CVSS
-            version is not 3.0 or 3.1, None is returned.
+    :return: The parsed CVSS information as a single dictionary
+    :rtype: dict or None
     """
-
-    # baseScore, baseSeverity, vectorString, and version are required
-    cvss_v3 = res.get("cvss_v3")
-    if (
-            not cvss_v3
-            or not (vector_string := cvss_v3.get("vector_string"))
-            or not (version := re.findall(r"3.0|3.1",
-                                          cvss_v3.get("vector_string", "")))
-            or not (base_score := cvss_v3.get("base_score"))
-            or (severity := res.get("severity")) not in
-            ["CRITICAL", "HIGH", "MEDIUM", "LOW", "NONE"]
-    ):
+    if len(props) < 8:
         return None
-    version = version[0]
-    cvss_v3_data = {
-        "baseScore": base_score,
-        "baseSeverity": severity,
-        "attackVector": cvss_v3.get("attack_vector"),
-        "privilegesRequired": cvss_v3.get("privileges_required"),
-        "userInteraction": cvss_v3.get("user_interaction"),
-        "scope": cvss_v3.get("scope"),
-        "version": version,
-        "vectorString": vector_string,
+    cvss_v3 = {
+        i["name"]: i["value"] for i in props if i["name"].startswith("cvss")
     }
 
-    return cvss_v3_data
+    return {
+        "baseScore": cvss_v3.get("cvssBaseScore"),
+        "attackVector": cvss_v3.get("cvssAttackVector"),
+        "privilegesRequired": cvss_v3.get("cvssPrivilegesRequired"),
+        "userInteraction": cvss_v3.get("cvssUserInteraction"),
+        "scope": cvss_v3.get("cvssScope"),
+        "baseSeverity": cvss_v3.get("cvssBaseSeverity"),
+        "version": cvss_v3.get("cvssVersion"),
+        "vectorString": cvss_v3.get("cvssVectorString"),
+    }
 
 
-def format_references(ref):
+def format_references(advisories):
     """
-    Formats the given references.
+    Formats the advisories as references.
 
-    Args:
-        ref (list): A list of references.
+    :param advisories: List of dictionaries of advisories online
+    :type advisories: list
 
-    Returns:
-        list: A list of dictionaries with the formatted references.
+    :return: A list of dictionaries with the formatted references.
+    :rtype: list
     """
+    ref = [i["url"] for i in advisories]
     fmt_refs = [{"summary": get_ref_summary(r), "url": r} for r in ref]
     ids = []
-    issues_regex = re.compile(
-        r"(?P<host>github|bitbucket|chromium)(?:.com|.org)/(?P<owner>["
-        r"\w\-.]+)/(?P<repo>[\w\-.]+)/issues/(?:detail\?id=)?(?P<id>\d+)",
-        re.IGNORECASE,
-    )
-    advisory_regex = re.compile(
-        r"(?P<org>[^\s/.]+).(?:com|org)/(?:\S+/)*/?(?P<id>[\w\-:]+)",
-        re.IGNORECASE,
-    )
-    bugzilla_regex = re.compile(
-        r"(?<=bugzilla.)(?P<owner>\S+)\.\w{3}/show_bug.cgi\?id=(?P<id>" r"\S+)",
-        re.IGNORECASE,
-    )
-    usn_regex = re.compile(
-        r"(?<=usn.ubuntu.com/)[\d\-]+|(?<=ubuntu.com/security/notices/USN-)["
-        r"\d\-]+",
-        re.IGNORECASE,
-    )
     id_types = ["Advisory", "Issue", "Ubuntu Security Notice", "Bugzilla"]
     parse = [i for i in fmt_refs if i.get("summary") in id_types]
     refs = [i for i in fmt_refs if i.get("summary") not in id_types]
@@ -1369,7 +1309,7 @@ def format_references(ref):
         summary = reference["summary"]
         if summary == "Advisory":
             url = url.replace("glsa/", "glsa-")
-            if adv := re.search(advisory_regex, url):
+            if adv := re.search(ADVISORY_REGEX, url):
                 system_name = (
                     (adv["org"].capitalize() + " Advisory")
                     .replace("Redhat", "Red Hat")
@@ -1379,7 +1319,7 @@ def format_references(ref):
                 )
                 ids.append({"system_name": system_name, "text": adv["id"]})
                 summary = system_name
-        elif issue := re.search(issues_regex, url):
+        elif issue := re.search(ISSUES_REGEX, url):
             summary = (
                 issue["host"].capitalize().replace("Github", "GitHub")
                 + " Issue"
@@ -1395,14 +1335,14 @@ def format_references(ref):
                     "text": issue["id"],
                 }
             )
-        elif bugzilla := re.search(bugzilla_regex, url):
+        elif bugzilla := re.search(BUGZILLA_REGEX, url):
             system_name = f"{bugzilla['owner'].capitalize()} Bugzilla"
             system_name = system_name.replace("Redhat", "Red Hat")
             ids.append(
                 {"system_name": f"{system_name} ID", "text": bugzilla["id"]}
             )
             summary = system_name
-        elif usn := re.search(usn_regex, url):
+        elif usn := re.search(USN_REGEX, url):
             ids.append({"system_name": summary, "text": f"USN-{usn[0]}"})
         refs.append({"summary": summary, "url": url})
     new_ids = {(idx["system_name"], idx["text"]) for idx in ids}
@@ -1415,20 +1355,21 @@ def get_ref_summary(url):
     """
     Returns the summary string associated with a given URL.
 
-    Parameters:
-        url (str): The URL to match against the patterns in the REF_MAP.
+    :param url: The URL to match against the patterns in the REF_MAP.
+    :type url: str
 
-    Returns:
-        str: The summary string corresponding to the matched pattern in REF_MAP.
-             If no match is found, an exception is raised.
+    :return: The summary string corresponding to the matched pattern in REF_MAP.
+    :rtype: str
+
+    :raises: TypeError if url is not a string
     """
-    if type(url) is not str:
+    if not isinstance(url, str):
         raise TypeError("url must be a string")
 
     return next(
         (
             value
-            for pattern, value in compiled_patterns.items()
+            for pattern, value in COMPILED_REF_PATTERNS.items()
             if pattern.search(url)
         ),
         "Other",
@@ -1437,13 +1378,13 @@ def get_ref_summary(url):
 
 def parse_revision_history(tracking):
     """
-    Parses the revision history of a tracking object.
+    Parses the revision history from the tracking data.
 
-    Args:
-        tracking (dict): The tracking object containing the revision history.
+    :param tracking: The tracking object containing the revision history
+    :type tracking: dict
 
-    Returns:
-        dict: The updated tracking object with the parsed revision history.
+    :return: The updated tracking object
+    :rtype: dict
     """
     hx = deepcopy(tracking.get("revision_history")) or []
     if not hx and (tracking.get("version")) != "1":
@@ -1534,11 +1475,11 @@ def import_product_tree(tree):
     """
     Set the product tree by loading it from a file.
 
-    Parameters:
-        tree (dict): The dictionary representing the tree.
+    :param tree: The dictionary representing the tree.
+    :type tree: dict
 
-    Returns:
-        dict: The product tree loaded from the file, or None if file is empty.
+    :return: The product tree loaded from the file, or None if file is empty.
+    :rtype: dict or None
     """
     product_tree = None
     if len(tree["easy_import"]) > 0:
@@ -1563,18 +1504,11 @@ def import_product_tree(tree):
 
 def parse_toml(metadata):
     """
-    Parses the given metadata in TOML format and generates an output dictionary.
+    Parses the given metadata from csaf.toml and generates an output dictionary.
 
-    Args:
-        metadata (dict): A dictionary containing the metadata in TOML format.
+    :param metadata: The data read from csaf.toml
 
-    Returns:
-        dict: The generated output dictionary.
-
-    Raises:
-        Exception: If the 'product_tree' entry is missing in the TOML file.
-        Exception: If the 'initial_release_date' is later than the
-        'current_release_date'.
+    :return: The processed metadata ready to use in the CSAF document.
     """
     tracking = parse_revision_history(metadata.get("tracking"))
     # FIXME: Could this be simplified as list comprehension without append
@@ -1610,41 +1544,26 @@ def toml_compatibility(metadata):
     """
     Applies any changes to the formatting of the TOML after a depscan
     minor or patch update
-    """
-    # Removed compatibility for 5.0.0 release
 
-    # The 4.3.0 TOML referenced revision_history as revision
-    # if metadata["depscan_version"] < "4.3.1":
-    #     metadata["tracking"]["revision_history"] = metadata["tracking"].get(
-    #         "revision"
-    #     )
-    # if metadata["tracking"].get("revision"):
-    #     del metadata["tracking"]["revision"]
+    :param metadata: The toml data
+    """
 
     return metadata
 
 
-def export_csaf(
-    results,
-    src_dir,
-    reports_dir,
-    vdr_file,
-    direct_purls,
-    reached_purls,
-):
+def export_csaf(pkg_vulnerabilities, src_dir, reports_dir, bom_file):
     """
-    Generates a CSAF JSON template from the given results.
+    Generates a CSAF 2.0 JSON document from the given results.
 
-    Parameters:
-        results (list): Raw results from scan
-        src_dir (str): The source directory.
-        reports_dir (str): The reports directory.
-        vdr_file (str): The BOM file path
-        direct_purls (dict): Package URLs with direct usages
-        reached_purls (dict): Package URLs with reachable flows
+    :param pkg_vulnerabilities: List of vulnerabilities
+    :type pkg_vulnerabilities: list
+    :param src_dir: The source directory.
+    :type src_dir: str
+    :param reports_dir: The reports directory.
+    :type reports_dir: str
+    :param bom_file: The BOM file path
+    :type bom_file: str
 
-    Returns:
-        None
     """
     toml_file_path = os.getenv(
         "DEPSCAN_CSAF_TEMPLATE", os.path.join(src_dir, "csaf.toml")
@@ -1652,33 +1571,33 @@ def export_csaf(
     metadata = import_csaf_toml(toml_file_path)
     metadata = toml_compatibility(metadata)
     template = parse_toml(metadata)
-    new_results = add_vulnerabilities(
-        template, results, direct_purls, reached_purls
-    )
+    new_results = add_vulnerabilities(template, pkg_vulnerabilities)
     new_results = cleanup_dict(new_results)
     [new_results, metadata] = verify_components_present(
-        new_results, metadata, vdr_file
+        new_results, metadata, bom_file
     )
 
     outfile = os.path.join(
         reports_dir,
         f"csaf_v{new_results['document']['tracking']['version']}.json",
     )
-    json.dump(new_results, open(outfile, "w", encoding="utf-8"), indent=4)
+    with open(outfile, "w", encoding="utf-8") as f:
+        json.dump(new_results, f, indent=4)
     LOG.info("CSAF report written to %s", outfile)
     write_toml(toml_file_path, metadata)
 
 
 def import_csaf_toml(toml_file_path):
     """
-    Reads the contents of the "csaf.toml" file, parses it as TOML, and converts
-    it to JSON format.
+    Reads the csaf.toml file and returns it as a dictionary.
 
-    Returns:
-        dict: A dictionary containing the parsed contents of the csaf.toml
+    :param toml_file_path: The path to the csaf.toml file.
+    :type toml_file_path: str
 
-    Raises:
-        TOMLDecodeError: If the TOML file contains duplicate keys or is invalid.
+    :return: A dictionary containing the parsed contents of the csaf.toml.
+    :rtype: dict
+
+    :raises TOMLDecodeError: If the TOML is invalid.
     """
     try:
         with open(toml_file_path, "r", encoding="utf-8") as f:
@@ -1690,7 +1609,7 @@ def import_csaf_toml(toml_file_path):
                     "duplicate keys and that any filepaths are properly escaped"
                     "if using Windows."
                 )
-                exit(1)
+                sys.exit(1)
     except FileNotFoundError:
         write_toml(toml_file_path)
         return import_csaf_toml(toml_file_path)
@@ -1700,13 +1619,13 @@ def import_csaf_toml(toml_file_path):
 
 def write_toml(toml_file_path, metadata=None):
     """
-    Retrieves the TOML template file from the given URL and saves it to the
-    specified file name.
+    Writes the toml data out to file. If no toml data is provided, a toml is
+    generated based on the default template.
 
-    Parameters:
-        toml_file_path (str): The filepath to save the TOML template to.
-
-        metadata (dict): A dictionary containing the TOML metadata.
+    :param toml_file_path: The filepath to save the TOML template to.
+    :type toml_file_path: str
+    :param metadata: A dictionary containing the TOML metadata.
+    :type metadata: dict
 
     """
     if not metadata:
@@ -1719,14 +1638,11 @@ def write_toml(toml_file_path, metadata=None):
 
 def cleanup_list(d):
     """
-    Generate a function comment for the given function body in a markdown code
-    block with the correct language syntax.
+    Cleans up a list by removing empty or None values recursively.
 
-    Args:
-        d (list): A list of dictionaries and strings.
+    :param d: The list to be cleaned up.
 
-    Returns:
-        list: A new list containing cleaned up entries from the input list.
+    :return: The new list or None
     """
     new_lst = []
     for dl in d:
@@ -1742,12 +1658,9 @@ def cleanup_dict(d):
     """
     Cleans up a dictionary by removing empty or None values recursively.
 
-    Parameters:
-    - d (dict): The dictionary to be cleaned up.
+    :param d: The dictionary to be cleaned up.
 
-    Returns:
-    - dict or None: The cleaned up dictionary. If the resulting dictionary is
-    empty, returns None.
+    :return: The new dictionary or None
     """
     new_dict = {}
     for key, value in d.items():
@@ -1764,11 +1677,18 @@ def cleanup_dict(d):
     return new_dict
 
 
-def import_root_component(vdr_file):
+def import_root_component(bom_file):
     """
-    Imports the root component from the given bom file into the csaf
+    Import the root component from the VDR file if no product tree is present
+    and gene    external references.
+
+    :param bom_file: The path to the VDR file.
+    :type bom_file: str
+
+    :returns: The product tree (dict) and additional references (list of dicts).
+    :rtype: tuple
     """
-    with open(vdr_file, "r", encoding="utf-8") as f:
+    with open(bom_file, "r", encoding="utf-8") as f:
         bom = json.load(f)
 
     refs = []
@@ -1799,28 +1719,26 @@ def import_root_component(vdr_file):
         LOG.info("Successfully imported root component into the product tree.")
     else:
         LOG.info(
-            "Unable to import root component for product tree, "
-            "so product tree will not be included."
+            "Unable to import root component for product tree, so product "
+            "tree will not be included."
         )
 
     return product_tree, refs
 
 
-def verify_components_present(data, metadata, vdr_file):
+def verify_components_present(data, metadata, bom_file):
     """
-    Verify if the required components are present in the given data, metadata,
-    and vdr_file.
+    Verify if the required components are present
 
-    Args:
-        data (dict): The data dictionary - this is the dictionary
-        representing the csaf document itself.
-        metadata (dict): The metadata dictionary - this stores the data that
-        will be written back out to the csaf.toml.
-        vdr_file (str): The path to the vdr_file.
+    :param data: The dictionary representing the csaf document itself.
+    :type data: dict
+    :param metadata: The dictionary that will be written back to the csaf.toml.
+    :type metadata: dict
+    :param bom_file: The path to the vdr_file.
+    :type bom_file: str
 
-    Returns:
-        tuple: A tuple containing the modified template dictionary and the
-        modified new_metadata dictionary.
+    :return: The modified template and metadata dictionaries.
+    :rtype: tuple
     """
     template = deepcopy(data)
     new_metadata = deepcopy(metadata)
@@ -1841,7 +1759,7 @@ def verify_components_present(data, metadata, vdr_file):
 
     # Add product tree if not present
     if not template.get("product_tree"):
-        [template["product_tree"], extra_ref] = import_root_component(vdr_file)
+        [template["product_tree"], extra_ref] = import_root_component(bom_file)
         if extra_ref and template["document"].get("references"):
             template["document"]["references"] += extra_ref
         elif extra_ref:
@@ -1856,28 +1774,26 @@ def verify_components_present(data, metadata, vdr_file):
 
     # Reset the id if it's one we've generated
     if re.match(
-        r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}_v",
-            new_metadata["tracking"]["id"]
+        r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}_v", new_metadata["tracking"]["id"]
     ):
         new_metadata["tracking"]["id"] = ""
 
     return template, new_metadata
 
 
-def add_vulnerabilities(data, results, direct_purls, reached_purls):
+def add_vulnerabilities(template, pkg_vulnerabilities):
     """
     Add vulnerabilities to the given data.
 
-    Parameters:
-    - data: The CSAF data so far.
-    - results: A list of results containing vulnerability information.
-    - direct_purls: A list of direct package URLs.
-    - reached_purls: A list of reached package URLs.
+    :param template: The CSAF data so far.
+    :type template: dict
+    :param pkg_vulnerabilities: The vulnerabilities to add.
+    :type pkg_vulnerabilities: list
 
-    Returns:
-    - new_results: The modified data with added vulnerability information.
+    :return: The modified data with added vulnerability information.
+    :rtype: dict
     """
-    new_results = deepcopy(data)
+    new_results = deepcopy(template)
     agg_score = set()
     severity_ref = {
         "CRITICAL": 1,
@@ -1887,29 +1803,10 @@ def add_vulnerabilities(data, results, direct_purls, reached_purls):
         "UNKNOWN": 5,
         "NONE": 6,
     }
-    affected_regex = re.compile(
-        r"(?P<lmod>[>=]{1,2})(?P<lower>\w+(?:.\w+)?(?:.\w+)?)-(?P<umod>[<=]{"
-        r"1,2})(?P<upper>\w+.(?:\w+.)?(?:\w+)?)",
-        re.IGNORECASE,
-    )
-    reached_dict = calculate_reached(reached_purls, direct_purls)
-
-    for r in results:
-        c = CsafOccurence(r)
-        new_vuln = c.to_dict()
-        agg_score.add(severity_ref.get(c.severity, 5))
-        if c.search_string:
-            found = reached_dict.get(c.search_string)
-            if not found:
-                new_vuln["flags"] = [
-                    {"label": "vulnerable_code_not_in_execute_path"}
-                ]
-            elif version_data := re.search(affected_regex, c.vrange):
-                if not version_helper(found, version_data.groupdict()):
-                    new_vuln["flags"] = [
-                        {"label": "vulnerable_code_not_in_execute_path"}
-                    ]
-
+    for r in pkg_vulnerabilities:
+        new_vuln = vdr_to_csaf(r)
+        if sev := new_vuln["scores"][0]["cvss_v3"].get("baseSeverity"):
+            agg_score.add(severity_ref.get(sev))
         new_results["vulnerabilities"].append(new_vuln)
     if agg_score := list(agg_score):
         agg_score.sort()
@@ -1921,62 +1818,3 @@ def add_vulnerabilities(data, results, direct_purls, reached_purls):
         new_results["document"]["aggregate_severity"] = {"text": agg_severity}
 
     return new_results
-
-
-def calculate_reached(reached_purls, direct_purls):
-    """
-    Calculate the reached packages and their versions.
-
-    This function takes two dictionaries, `reached_purls` and `direct_purls`, as
-    input. `reached_purls` contains the reached packages with their URLs, while
-    `direct_purls` contains the direct packages with their URLs. The function
-    calculates the reached packages and their versions by parsing the URLs.
-
-    Parameters:
-        reached_purls (dict): A dictionary containing the reached packages with
-            their URLs.
-        direct_purls (dict): A dictionary containing the direct packages with
-            their URLs.
-
-    Returns:
-        dict: A dictionary containing the reached packages as keys and a list
-        of versions as values.
-    """
-    reached_dict = {}
-    reached_regex = re.compile(
-        r"(?P<pkg>[^/]+/[^/]+)@(?P<version>\w+.(" r"?:\w+.)?(?:\w+)?)",
-        re.IGNORECASE,
-    )
-    for k in reached_purls.keys() | direct_purls.keys():
-        if result := re.search(reached_regex, k):
-            pkg = result["pkg"]
-            version = result["version"]
-            reached_dict.setdefault(pkg, []).append(version)
-    return reached_dict
-
-
-def version_helper(reached, vdata):
-    """
-    Determines if the vulnerability includes the reached version.
-
-    Args:
-        reached (list): Package versions that have been reached.
-        vdata (dict): A dictionary containing information about the
-        version range to be checked.
-            - `lower` (str): The lower bound of the version range.
-            - `lmod` (str): The lower bound modifier. Possible values are `">"`
-                and `">="`.
-            - `upper` (str): The upper bound of the version range.
-            - `umod` (str): The upper bound modifier. Possible values are `<"`
-                and `"<="`.
-
-    Returns:
-        bool: True if the version `reached` satisfies the conditions specified
-        by `x`, False otherwise.
-    """
-    mie = vdata["lower"] if vdata["lmod"] != ">=" else None
-    mae = vdata["upper"] if vdata["umod"] != "<=" else None
-    return any(
-        version_compare(_, vdata["lower"], vdata["upper"], mie, mae)
-        for _ in reached
-    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "toml",
     "pdfkit",
     "Jinja2",
+    "packageurl-python",
 ]
 
 requires-python = ">=3.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "pdfkit",
     "Jinja2",
     "packageurl-python",
+    "cvss",
 ]
 
 requires-python = ">=3.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "owasp-depscan"
-version = "5.1.4"
+version = "5.1.5"
 description = "Fully open-source security audit for project dependencies based on known vulnerabilities and advisories."
 authors = [
     {name = "Team AppThreat", email = "cloud@appthreat.com"},

--- a/test/test_analysis.py
+++ b/test/test_analysis.py
@@ -747,9 +747,9 @@ def test_cvss_to_vdr():
         "severity": "HIGH",
         "id": "CVE-2023-37788",
     }
-    assert cvss_to_vdr(res) is None
+    assert cvss_to_vdr(res) == {}
     res["cvss_v3"] = {}
-    assert cvss_to_vdr(res) is None
+    assert cvss_to_vdr(res) == {}
     # Test missing or pre-3.0 vector string
     res = {
         "cvss_v3": {
@@ -767,13 +767,13 @@ def test_cvss_to_vdr():
         "severity": "HIGH",
         "id": "CVE-2023-37788",
     }
-    assert cvss_to_vdr(res) is None
+    assert cvss_to_vdr(res) == {}
     res["cvss_v3"]["vector_string"] = "CVSS:2.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I"
-    assert cvss_to_vdr(res) is None
+    assert cvss_to_vdr(res) == {}
     res["cvss_v3"]["vector_string"] = ""
-    assert cvss_to_vdr(res) is None
+    assert cvss_to_vdr(res) == {}
     res["cvss_v3"]["vector_string"] = None
-    assert cvss_to_vdr(res) is None
+    assert cvss_to_vdr(res) == {}
     # Test missing base score
     res = {
         "cvss_v3": {
@@ -791,10 +791,10 @@ def test_cvss_to_vdr():
         "severity": "HIGH",
         "id": "CVE-2023-37788",
     }
-    assert cvss_to_vdr(res) is None
+    assert cvss_to_vdr(res) == {}
     res["cvss_v3"]["base_score"] = ""
-    assert cvss_to_vdr(res) is None
+    assert cvss_to_vdr(res) == {}
     res["cvss_v3"]["base_score"] = None
-    assert cvss_to_vdr(res) is None
+    assert cvss_to_vdr(res) == {}
 
 

--- a/test/test_analysis.py
+++ b/test/test_analysis.py
@@ -4,7 +4,7 @@ import os
 import pytest
 
 from depscan.lib import analysis
-from depscan.lib.analysis import cvss_to_vdr, split_cwe
+from depscan.lib.analysis import cvss_to_vdr, get_version_range, split_cwe
 
 
 @pytest.fixture
@@ -796,5 +796,27 @@ def test_cvss_to_vdr():
     assert cvss_to_vdr(res) == {}
     res["cvss_v3"]["base_score"] = None
     assert cvss_to_vdr(res) == {}
+
+
+def test_get_version_range():
+    # Test empty
+    assert get_version_range({}, "") == {}
+
+    # Test all components present
+    package_issue = {
+        'affected_location': {
+            'version': '>=2.9.0-<3.0.0'
+        }, 'fixed_location': '3.0.0'}
+    purl = "pkg:maven/org.apache.logging.log4j/log4j-api@2.12.1?type=jar"
+    assert get_version_range(package_issue, purl) == {
+        "name": "affectedVersionRange",
+        "value": "org.apache.logging.log4j/log4j-api@>=2.9.0-<3.0.0"
+    }
+
+    # Test invalid purl
+    purl = "maven/org.apache.logging.log4j/log4j-api@2.12.1?type=jar"
+    assert get_version_range(package_issue, purl) == {
+        'name': 'affectedVersionRange',
+        'value': 'maven/org.apache.logging.log4j/log4j-api@>=2.9.0-<3.0.0'}
 
 

--- a/test/test_analysis.py
+++ b/test/test_analysis.py
@@ -4,7 +4,7 @@ import os
 import pytest
 
 from depscan.lib import analysis
-from depscan.lib.analysis import cvss_to_vdr, get_version_range, split_cwe
+from depscan.lib.analysis import cvss_to_vdr_rating, get_version_range, split_cwe
 
 
 @pytest.fixture
@@ -702,100 +702,33 @@ def test_split_cwe():
     assert split_cwe("[CWE-20, CWE-1333]") == ([20, 1333])
 
 
-def test_cvss_to_vdr():
+def test_cvss_to_vdr_rating():
+    res = {
+        "cvss_v3": {},
+        "severity": "HIGH",
+    }
+    # Test missing score and vector string
+    assert cvss_to_vdr_rating(res) == [
+        {'method': 'CVSSv31', 'score': 2.0, 'severity': 'high'}]
     # Test parsing
-    res = {
-        "cvss_v3": {
-            "attack_complexity": "LOW",
-            "attack_vector": "NETWORK",
-            "availability_impact": "HIGH",
-            "base_score": 7.5,
-            "impact_score": 7.5,
-            "confidentiality_impact": "NONE",
-            "integrity_impact": "NONE",
-            "privileges_required": "NONE",
-            "scope": "UNCHANGED",
-            "user_interaction": "NONE",
-            "vector_string": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
-        },
-        "severity": "HIGH",
-        "id": "CVE-2023-37788",
-    }
-    assert cvss_to_vdr(res) == [
-        {'name': 'cvssVersion', 'value': '3.1'},
-        {'name': 'cvssBaseScore', 'value': 7.5},
-        {'name': 'cvssVectorString',
-         'value': 'CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H'},
-        {'name': 'cvssAttackVector', 'value': 'NETWORK'},
-        {'name': 'cvssPrivilegesRequired', 'value': 'NONE'},
-        {'name': 'cvssUserInteraction', 'value': 'NONE'},
-        {'name': 'cvssScope', 'value': 'UNCHANGED'},
-        {'name': 'cvssBaseSeverity', 'value': 'HIGH'}]
-    res["cvss_v3"]["vector_string"] = "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I"
-    assert cvss_to_vdr(res) == [
-        {'name': 'cvssVersion', 'value': '3.0'},
-        {'name': 'cvssBaseScore', 'value': 7.5},
-        {'name': 'cvssVectorString',
-         'value': 'CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I'},
-        {'name': 'cvssAttackVector', 'value': 'NETWORK'},
-        {'name': 'cvssPrivilegesRequired', 'value': 'NONE'},
-        {'name': 'cvssUserInteraction', 'value': 'NONE'},
-        {'name': 'cvssScope', 'value': 'UNCHANGED'},
-        {'name': 'cvssBaseSeverity', 'value': 'HIGH'}]
-    # Test no cvss_v3
-    res = {
-        "severity": "HIGH",
-        "id": "CVE-2023-37788",
-    }
-    assert cvss_to_vdr(res) == {}
-    res["cvss_v3"] = {}
-    assert cvss_to_vdr(res) == {}
-    # Test missing or pre-3.0 vector string
-    res = {
-        "cvss_v3": {
-            "attack_complexity": "LOW",
-            "attack_vector": "NETWORK",
-            "availability_impact": "HIGH",
-            "base_score": 7.5,
-            "impact_score": 7.5,
-            "confidentiality_impact": "NONE",
-            "integrity_impact": "NONE",
-            "privileges_required": "NONE",
-            "scope": "UNCHANGED",
-            "user_interaction": "NONE",
-        },
-        "severity": "HIGH",
-        "id": "CVE-2023-37788",
-    }
-    assert cvss_to_vdr(res) == {}
-    res["cvss_v3"]["vector_string"] = "CVSS:2.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I"
-    assert cvss_to_vdr(res) == {}
-    res["cvss_v3"]["vector_string"] = ""
-    assert cvss_to_vdr(res) == {}
-    res["cvss_v3"]["vector_string"] = None
-    assert cvss_to_vdr(res) == {}
-    # Test missing base score
-    res = {
-        "cvss_v3": {
-            "attack_complexity": "LOW",
-            "attack_vector": "NETWORK",
-            "availability_impact": "HIGH",
-            "impact_score": 7.5,
-            "confidentiality_impact": "NONE",
-            "integrity_impact": "NONE",
-            "privileges_required": "NONE",
-            "scope": "UNCHANGED",
-            "user_interaction": "NONE",
-            "vector_string": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
-        },
-        "severity": "HIGH",
-        "id": "CVE-2023-37788",
-    }
-    assert cvss_to_vdr(res) == {}
-    res["cvss_v3"]["base_score"] = ""
-    assert cvss_to_vdr(res) == {}
-    res["cvss_v3"]["base_score"] = None
-    assert cvss_to_vdr(res) == {}
+    res["cvss_v3"]["vector_string"] = ("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I"
+                                       ":N/A:H")
+    res["cvss_score"] = 7.5
+
+    assert cvss_to_vdr_rating(res) == [{
+        'method': 'CVSSv31',
+        'score': 7.5,
+        'severity': 'high',
+        'vector': 'CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H'
+    }]
+    res["cvss_v3"]["vector_string"] = ("CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I"
+                                       ":N/A:H")
+    assert cvss_to_vdr_rating(res) == [{
+        'method': 'CVSSv3',
+        'score': 7.5,
+        'severity': 'high',
+        'vector': 'CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H'
+    }]
 
 
 def test_get_version_range():

--- a/test/test_csaf.py
+++ b/test/test_csaf.py
@@ -1,11 +1,12 @@
 import os.path
 
+
 from depscan.lib.csaf import (
-    CsafOccurence,
     add_vulnerabilities,
     cleanup_dict,
     cleanup_list,
     format_references,
+    get_acknowledgements,
     get_product_status,
     get_ref_summary,
     import_csaf_toml,
@@ -15,7 +16,6 @@ from depscan.lib.csaf import (
     parse_revision_history,
     parse_toml,
     verify_components_present,
-    version_helper,
 )
 
 
@@ -248,25 +248,63 @@ def test_get_ref_summary():
 
 
 def test_format_references():
-    ref = [
-        "https://access.redhat.com/errata/RHSA-2023:5484",
-        "https://bugzilla.redhat.com/show_bug.cgi?id=2224245",
-        "https://nvd.nist.gov/vuln/detail/cve-2021-1234",
-        "https://github.com/advisories/GHSA-1234-1234-1234",
-        "https://github.com/user/repo/security/advisories/GHSA-5432-5432-5432",
-        "https://github.com/user/repo/pull/123",
-        "https://github.com/user/repo/commit/123",
-        "https://example.com",
-        "https://github.com/user/repo/release",
-        "https://github.com/user/repo",
-        "https://bugzilla.redhat.com/show_bug.cgi?id=cve-2021-1234",
-        "https://github.com/FasterXML/jackson-databind/issues/2816",
-        "https://sec.cloudapps.cisco.com/security/center/content"
-        "/CiscoSecurityAdvisory/cisco-sa-apache-log4j-qRuKNEbd",
-        "https://bitbucket.org/snakeyaml/snakeyaml/issues/525",
-        "https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=47027",
+    advisories = [
+        {
+            "title": "testing",
+            "url": "https://access.redhat.com/errata/RHSA-2023:5484",
+        },
+        {
+            "title": "testing",
+            "url": "https://bugzilla.redhat.com/show_bug.cgi?id=2224245",
+        },
+        {
+            "title": "testing",
+            "url": "https://nvd.nist.gov/vuln/detail/cve-2021-1234",
+        },
+        {
+            "title": "testing",
+            "url": "https://github.com/advisories/GHSA-1234-1234-1234",
+        },
+        {
+            "title": "testing",
+            "url": (
+                "https://github.com/user/repo/security/advisories/GHSA"
+                "-5432-5432-5432"
+            ),
+        },
+        {"title": "testing", "url": "https://github.com/user/repo/pull/123"},
+        {"title": "testing", "url": "https://github.com/user/repo/commit/123"},
+        {"title": "testing", "url": "https://example.com"},
+        {"title": "testing", "url": "https://github.com/user/repo/release"},
+        {"title": "testing", "url": "https://github.com/user/repo"},
+        {
+            "title": "testing",
+            "url": "https://bugzilla.redhat.com/show_bug.cgi?id=cve-2021-1234",
+        },
+        {
+            "title": "testing",
+            "url": "https://github.com/FasterXML/jackson-databind/issues/2816",
+        },
+        {
+            "title": "testing",
+            "url": (
+                "https://sec.cloudapps.cisco.com/security/center/content"
+                "/CiscoSecurityAdvisory/cisco-sa-apache-log4j-qRuKNEbd"
+            ),
+        },
+        {
+            "title": "testing",
+            "url": "https://bitbucket.org/snakeyaml/snakeyaml/issues/525",
+        },
+        {
+            "title": "testing",
+            "url": (
+                "https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=4707"
+            ),
+        },
     ]
-    [ids, refs] = format_references(ref)
+
+    [ids, refs] = format_references(advisories)
     # For consistency in tests
     ids = sorted(ids, key=lambda x: x["text"])
     refs = sorted(refs, key=lambda x: x["url"])
@@ -276,7 +314,7 @@ def test_format_references():
             "system_name": "GitHub Issue [FasterXML/jackson-databind]",
             "text": "2816",
         },
-        {"system_name": "Chromium Issue [oss-fuzz]", "text": "47027"},
+        {"system_name": "Chromium Issue [oss-fuzz]", "text": "4707"},
         {"system_name": "Bitbucket Issue [snakeyaml/snakeyaml]", "text": "525"},
         {"system_name": "GitHub Advisory", "text": "GHSA-1234-1234-1234"},
         {"system_name": "GitHub Advisory", "text": "GHSA-5432-5432-5432"},
@@ -298,7 +336,7 @@ def test_format_references():
         },
         {
             "summary": "Chromium Issue",
-            "url": "https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=47027",
+            "url": "https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=4707",
         },
         {
             "summary": "Red Hat Bugzilla",
@@ -332,8 +370,10 @@ def test_format_references():
         },
         {
             "summary": "GitHub Advisory",
-            "url": "https://github.com/user/repo/security/advisories/GHSA"
-            "-5432-5432-5432",
+            "url": (
+                "https://github.com/user/repo/security/advisories/GHSA"
+                "-5432-5432-5432"
+            ),
         },
         {
             "summary": "CVE Record",
@@ -341,33 +381,38 @@ def test_format_references():
         },
         {
             "summary": "Cisco Advisory",
-            "url": "https://sec.cloudapps.cisco.com/security/center/content"
-            "/CiscoSecurityAdvisory/cisco-sa-apache-log4j-qRuKNEbd",
+            "url": (
+                "https://sec.cloudapps.cisco.com/security/center/content"
+                "/CiscoSecurityAdvisory/cisco-sa-apache-log4j-qRuKNEbd"
+            ),
         },
     ]
 
 
 def test_parse_cwe():
-    assert parse_cwe("['CWE-20', 'CWE-668']") == (
-        {"id": "CWE-20", "name": "Improper Input Validation"},
+    assert parse_cwe([20, 668]) == (
+        {"id": "20", "name": "Improper Input Validation"},
         [
             {
-                "title": "Additional CWE: CWE-668",
+                "title": "Additional CWE: 668",
                 "audience": "developers",
                 "category": "other",
                 "text": "Exposure of Resource to Wrong Sphere",
             }
         ],
     )
-    assert parse_cwe("CWE-1333") == (
+    assert parse_cwe([1333]) == (
         {
-            "id": "CWE-1333",
+            "id": "1333",
             "name": "Inefficient Regular Expression Complexity",
         },
         [],
     )
-    assert parse_cwe("") == (None, [])
-    assert parse_cwe("CWE-000") == (None, [])
+    assert parse_cwe([]) == (None, [])
+    assert parse_cwe([1010101]) == (
+        {"id": "1010101", "name": "UNABLE TO LOCATE CWE NAME"},
+        [],
+    )
 
 
 def test_parse_toml():
@@ -394,325 +439,79 @@ def test_parse_toml():
 
 
 def test_parse_cvss():
-    # Test parsing
-    res = {
-        "cvss_v3": {
-            "attack_complexity": "LOW",
-            "attack_vector": "NETWORK",
-            "availability_impact": "HIGH",
-            "base_score": 7.5,
-            "impact_score": 7.5,
-            "confidentiality_impact": "NONE",
-            "integrity_impact": "NONE",
-            "privileges_required": "NONE",
-            "scope": "UNCHANGED",
-            "user_interaction": "NONE",
-            "vector_string": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+    props = [
+        {"name": "cvssVersion", "value": "3.0"},
+        {"name": "cvssBaseScore", "value": 9.8},
+        {
+            "name": "cvssVectorString",
+            "value": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
         },
-        "severity": "HIGH",
-        "id": "CVE-2023-37788",
-    }
-    assert parse_cvss(res) == {
-        "baseScore": 7.5,
+        {"name": "cvssAttackVector", "value": "NETWORK"},
+        {"name": "cvssPrivilegesRequired", "value": "NONE"},
+        {"name": "cvssUserInteraction", "value": "NONE"},
+        {"name": "cvssScope", "value": "UNCHANGED"},
+        {"name": "cvssBaseSeverity", "value": "CRITICAL"},
+        {"name": "affected_version_range", "value": ">=2.9.0-<2.9.8"},
+    ]
+    assert parse_cvss(props) == {
         "attackVector": "NETWORK",
+        "baseScore": 9.8,
+        "baseSeverity": "CRITICAL",
         "privilegesRequired": "NONE",
-        "userInteraction": "NONE",
         "scope": "UNCHANGED",
-        "baseSeverity": "HIGH",
-        "version": "3.1",
-        "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
-    }
-    res["cvss_v3"]["vector_string"] = "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I"
-    assert parse_cvss(res) == {
-        "baseScore": 7.5,
-        "attackVector": "NETWORK",
-        "privilegesRequired": "NONE",
         "userInteraction": "NONE",
-        "scope": "UNCHANGED",
-        "baseSeverity": "HIGH",
+        "vectorString": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
         "version": "3.0",
-        "vectorString": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I",
     }
-    # Test no cvss_v3
-    res = {
-        "severity": "HIGH",
-        "id": "CVE-2023-37788",
-    }
-    assert parse_cvss(res) is None
-    res["cvss_v3"] = {}
-    assert parse_cvss(res) is None
-    # Test missing or pre-3.0 vector string
-    res = {
-        "cvss_v3": {
-            "attack_complexity": "LOW",
-            "attack_vector": "NETWORK",
-            "availability_impact": "HIGH",
-            "base_score": 7.5,
-            "impact_score": 7.5,
-            "confidentiality_impact": "NONE",
-            "integrity_impact": "NONE",
-            "privileges_required": "NONE",
-            "scope": "UNCHANGED",
-            "user_interaction": "NONE",
+    props = [
+        {
+            "name": "depscan:insights",
+            "value": "Direct dependency\\nVendor Confirmed\\nKnown Exploits",
         },
-        "severity": "HIGH",
-        "id": "CVE-2023-37788",
-    }
-    assert parse_cvss(res) is None
-    res["cvss_v3"]["vector_string"] = "CVSS:2.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I"
-    assert parse_cvss(res) is None
-    res["cvss_v3"]["vector_string"] = ""
-    assert parse_cvss(res) is None
-    res["cvss_v3"]["vector_string"] = None
-    assert parse_cvss(res) is None
-    # Test missing base score
-    res = {
-        "cvss_v3": {
-            "attack_complexity": "LOW",
-            "attack_vector": "NETWORK",
-            "availability_impact": "HIGH",
-            "impact_score": 7.5,
-            "confidentiality_impact": "NONE",
-            "integrity_impact": "NONE",
-            "privileges_required": "NONE",
-            "scope": "UNCHANGED",
-            "user_interaction": "NONE",
-            "vector_string": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
-        },
-        "severity": "HIGH",
-        "id": "CVE-2023-37788",
-    }
-    assert parse_cvss(res) is None
-    res["cvss_v3"]["base_score"] = ""
-    assert parse_cvss(res) is None
-    res["cvss_v3"]["base_score"] = None
-    assert parse_cvss(res) is None
+        {"name": "depscan:prioritized", "value": "true"},
+        {"name": "cvssVersion", "value": "3.0"},
+        {"name": "affected_version_range", "value": ">=2.9.0-<2.9.8"},
+    ]
+    assert parse_cvss(props) is None
 
 
 def test_get_product_status():
-    assert get_product_status(
+    affected = [
         {
-            "affected_location": {
-                "cpe_uri": "cpe:2.3:a:npm:taffydb:*:*:*:*:*:*:*:*",
-                "package": "taffydb",
-                "version": "<=2.7.3",
-            },
-            "fixed_location": None,
-        },
-        "1089386|taffydb|2.6.2",
-    ) == (
-        "taffydb",
-        {"known_affected": ["taffydb:<=2.7.3"]},
-        "<=2.7.3",
-        "taffydb",
-    )
-
-    assert get_product_status(
-        {
-            "affected_location": {
-                "cpe_uri": "cpe:2.3:a:npm:taffydb:*:*:*:*:*:*:*:*",
-                "package": "taffydb",
-                "version": "<=2.7.3",
-            },
-            "fixed_location": None,
-        },
-        "1089386_32636283|taffygroup|taffydb|2.6.2",
-    ) == (
-        "taffydb",
-        {"known_affected": ["taffydb:<=2.7.3"]},
-        "<=2.7.3",
-        "taffygroup/taffydb",
-    )
-
-
-def test_csaf_occurence():
-    res = [
-        {
-            "id": "CVE-2019-10790",
-            "problem_type": "['CWE-20', 'CWE-668']",
-            "type": "npm",
-            "severity": None,
-            "cvss_score": "7.5",
-            "cvss_v3": {
-                "base_score": 7.5,
-                "exploitability_score": 7.5,
-                "impact_score": 7.5,
-                "attack_vector": "NETWORK",
-                "attack_complexity": "LOW",
-                "privileges_required": "NONE",
-                "user_interaction": "REQUIRED",
-                "scope": "UNCHANGED",
-                "confidentiality_impact": "HIGH",
-                "integrity_impact": "HIGH",
-                "availability_impact": "HIGH",
-                "vector_string": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L",
-            },
-            "package_issue": {
-                "affected_location": {
-                    "cpe_uri": "cpe:2.3:a:npm:taffydb:*:*:*:*:*:*:*:*",
-                    "package": "taffydb",
-                    "version": "<=2.7.3",
-                },
-                "fixed_location": None,
-            },
-            "short_description": "# TaffyDB can allow access to any data items "
-            "in the DB\nTaffyDB allows attackers to forge "
-            "adding additional properties into user input "
-            "processed by taffy which can allow access to "
-            "any data items in the DB. Taffy sets an "
-            "internal index for each data item in its DB. "
-            "However, it is found that the internal index "
-            "can be forged by adding additional properties "
-            "into user input. If index is found in the "
-            "query, TaffyDB will ignore other query "
-            "conditions and directly return the indexed "
-            "data item. Moreover, the internal index is in "
-            "an easily guessable format (e.g., "
-            "T000002R000001). As such, attackers can use "
-            "this vulnerability to access any data items in "
-            "the DB. **Note:** `taffy` and its successor "
-            "package `taffydb` are not maintained.\nNone",
-            "long_description": None,
-            "related_urls": [],
-            "effective_severity": "HIGH",
-            "source_update_time": "2023-01-30T19:22:18",
-            "source_orig_time": "2020-02-19T16:43:42",
-            "matched_by": "1089386|taffydb|2.6.2",
-        },
-        {
-            "id": "CVE-2023-36665",
-            "problem_type": "CWE-1321",
-            "type": "npm",
-            "severity": "CRITICAL",
-            "cvss_score": "9.8",
-            "cvss_v3": {
-                "base_score": 9.8,
-                "exploitability_score": 9.8,
-                "impact_score": 9.8,
-                "attack_vector": "NETWORK",
-                "attack_complexity": "LOW",
-                "privileges_required": "NONE",
-                "user_interaction": "REQUIRED",
-                "scope": "UNCHANGED",
-                "confidentiality_impact": "CRITICAL",
-                "integrity_impact": "CRITICAL",
-                "availability_impact": "CRITICAL",
-                "vector_string": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
-            },
-            "package_issue": {
-                "affected_location": {
-                    "cpe_uri": "cpe:2.3:a:npm:protobufjs:*:*:*:*:*:*:*:*",
-                    "package": "protobufjs",
-                    "version": ">=7.0.0-<7.2.4",
-                },
-                "fixed_location": "7.2.4",
-            },
-            "short_description": "# protobufjs Prototype Pollution "
-            "vulnerability\nprotobuf.js ("
-            "aka protobufjs) 6.10.0 until 6.11.4 and 7.0.0 until 7.2.4 "
-            "allows Prototype Pollution, a different vulnerability than "
-            "CVE-2022-25878. A user-controlled protobuf message can be used "
-            "by an attacker to pollute the prototype of Object.prototype by "
-            "adding and overwriting its data and functions. Exploitation can "
-            "involve: (1) using the function parse to parse protobuf "
-            "messages on the fly, (2) loading .proto files by using "
-            "load/loadSync functions, or (3) providing untrusted input to "
-            "the functions ReflectionObject.setParsedOption and "
-            "util.setProperty. NOTE: this CVE Record is about "
-            "`Object.constructor.prototype.<new-property> = ...;` whereas "
-            "CVE-2022-25878 was about `Object.__proto__.<new-property> = "
-            "...;` instead.",
-            "long_description": None,
-            "related_urls": [
-                "https://github.com/markdown-it/markdown-it/security"
-                "/advisories/GHSA-6vfc-qv3f-vr6c",
-                "https://nvd.nist.gov/vuln/detail/CVE-2022-21670",
-                "https://github.com/markdown-it/markdown-it/commit"
-                "/ffc49ab46b5b751cd2be0aabb146f2ef84986101",
-                "https://github.com/markdown-it/markdown-it",
+            "ref": (
+                "pkg:maven/org.apache.httpcomponents/httpclient@4.5.5?type=jar"
+            ),
+            "versions": [
+                {"version": "4.5.5", "status": "affected"},
+                {"version": "4.5.13", "status": "unaffected"},
             ],
-            "effective_severity": "CRITICAL",
-            "source_update_time": "2023-08-15T21:16:36",
-            "source_orig_time": "2023-07-05T15:30:24",
-            "matched_by": "2499923747_2499958328|npm|protobufjs|7.1.2",
-        },
+        }
     ]
-    occs = []
-    for r in res:
-        vuln = CsafOccurence(r)
-        occs.append(vuln)
-    result = [o.to_dict() for o in occs]
-    assert result == [
-        {'cve': 'CVE-2019-10790',
-  'cwe': {'id': 'CWE-20', 'name': 'Improper Input Validation'},
-  'discovery_date': '2020-02-19T16:43:42',
-  'ids': [],
-  'notes': [{'audience': 'developers',
-             'category': 'other',
-             'text': 'Exposure of Resource to Wrong Sphere',
-             'title': 'Additional CWE: CWE-668'},
-            {'category': 'general',
-             'details': 'Vulnerability Description',
-             'text': '# TaffyDB can allow access to any data items in the DB '
-                     'TaffyDB allows attackers to forge adding additional '
-                     'properties into user input processed by taffy which can '
-                     'allow access to any data items in the DB. Taffy sets an '
-                     'internal index for each data item in its DB. However, it '
-                     'is found that the internal index can be forged by adding '
-                     'additional properties into user input. If index is found '
-                     'in the query, TaffyDB will ignore other query conditions '
-                     'and directly return the indexed data item. Moreover, the '
-                     'internal index is in an easily guessable format (e.g., '
-                     'T000002R000001). As such, attackers can use this '
-                     'vulnerability to access any data items in the DB. '
-                     '**Note:** `taffy` and its successor package `taffydb` '
-                     'are not maintained. None'}],
-  'product_status': {'known_affected': ['taffydb:<=2.7.3']},
-  'references': []},
-        {'cve': 'CVE-2023-36665',
-  'cwe': {'id': 'CWE-1321',
-          'name': 'Improperly Controlled Modification of Object Prototype '
-                  'Attributes'},
-  'discovery_date': '2023-07-05T15:30:24',
-  'ids': [{'system_name': 'GitHub Advisory', 'text': 'GHSA-6vfc-qv3f-vr6c'}],
-  'notes': [{'category': 'general',
-             'details': 'Vulnerability Description',
-             'text': '# protobufjs Prototype Pollution vulnerability '
-                     'protobuf.js (aka protobufjs) 6.10.0 until 6.11.4 and '
-                     '7.0.0 until 7.2.4 allows Prototype Pollution, a '
-                     'different vulnerability than CVE-2022-25878. A '
-                     'user-controlled protobuf message can be used by an '
-                     'attacker to pollute the prototype of Object.prototype by '
-                     'adding and overwriting its data and functions. '
-                     'Exploitation can involve: (1) using the function parse '
-                     'to parse protobuf messages on the fly, (2) loading '
-                     '.proto files by using load/loadSync functions, or (3) '
-                     'providing untrusted input to the functions '
-                     'ReflectionObject.setParsedOption and util.setProperty. '
-                     'NOTE: this CVE Record is about '
-                     '`Object.constructor.prototype.<new-property> = ...;` '
-                     'whereas CVE-2022-25878 was about '
-                     '`Object.__proto__.<new-property> = ...;` instead.'}],
-  'product_status': {'fixed': ['protobufjs:7.2.4'],
-                     'known_affected': ['protobufjs:>=7.0.0-<7.2.4']},
-  'references': [{'summary': 'CVE Record',
-                  'url': 'https://nvd.nist.gov/vuln/detail/CVE-2022-21670'},
-                 {'summary': 'GitHub Commit',
-                  'url': 'https://github.com/markdown-it/markdown-it/commit/ffc49ab46b5b751cd2be0aabb146f2ef84986101'},
-                 {'summary': 'GitHub Repository',
-                  'url': 'https://github.com/markdown-it/markdown-it'},
-                 {'summary': 'GitHub Advisory',
-                  'url': 'https://github.com/markdown-it/markdown-it/security/advisories/GHSA-6vfc-qv3f-vr6c'}],
-  'scores': [{'cvss_v3': {'attackVector': 'NETWORK',
-                          'baseScore': 9.8,
-                          'baseSeverity': 'CRITICAL',
-                          'privilegesRequired': 'NONE',
-                          'scope': 'UNCHANGED',
-                          'userInteraction': 'REQUIRED',
-                          'vectorString': 'CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H',
-                          'version': '3.1'},
-              'products': ['protobufjs']}]}
+    assert get_product_status(affected) == ({
+        "known_affected": [
+            "pkg:maven/org.apache.httpcomponents/httpclient@4.5.5?type=jar"
+        ],
+        "fixed": [
+            "pkg:maven/org.apache.httpcomponents/httpclient@4.5.13?type=jar"
+        ],
+    })
+    affected = [
+        {
+            "ref": (
+                "pkg:maven/org.apache.httpcomponents/httpclient@4.5.5?type=jar"
+            ),
+            "versions": [
+                {"version": "4.5.5", "status": "affected"},
+            ],
+        }
     ]
+
+    assert get_product_status(affected) == ({
+        "fixed": [],
+        "known_affected": [
+            "pkg:maven/org.apache.httpcomponents/httpclient@4.5.5?type=jar"
+        ],
+    })
 
 
 def test_import_root_component():
@@ -727,8 +526,10 @@ def test_import_root_component():
                 "name": "vuln-spring",
                 "product_id": "vuln-spring:0.0.1-SNAPSHOT",
                 "product_identification_helper": {
-                    "purl": "pkg:maven/com.example/vuln-spring@0.0.1-SNAPSHOT"
-                    "?type=jar"
+                    "purl": (
+                        "pkg:maven/com.example/vuln-spring@0.0.1-SNAPSHOT"
+                        "?type=jar"
+                    )
                 },
             }
         ]
@@ -737,13 +538,17 @@ def test_import_root_component():
     assert ref == [
         {
             "summary": "website",
-            "url": "https://projects.spring.io/spring-boot/#/spring"
-            "-boot-starter-parent/vuln-spring",
+            "url": (
+                "https://projects.spring.io/spring-boot/#/spring"
+                "-boot-starter-parent/vuln-spring"
+            ),
         },
         {
             "summary": "vcs",
-            "url": "https://github.com/spring-projects/spring-boot"
-            "/spring-boot-starter-parent/vuln-spring",
+            "url": (
+                "https://github.com/spring-projects/spring-boot"
+                "/spring-boot-starter-parent/vuln-spring"
+            ),
         },
     ]
 
@@ -777,221 +582,10 @@ def test_verify_components_present():
                 "id": "2023-11-22T10:35:03_v1",
             },
         },
-        "vulnerabilities": [
-            {
-                "id": "CVE-2020-36180",
-                "problem_type": "CWE-502",
-                "type": "fasterxml",
-                "severity": "HIGH",
-                "cvss_score": "8.1",
-                "cvss_v3": {
-                    "base_score": 8.1,
-                    "exploitability_score": 2.2,
-                    "impact_score": 5.9,
-                    "attack_vector": "NETWORK",
-                    "attack_complexity": "HIGH",
-                    "privileges_required": "NONE",
-                    "user_interaction": "NONE",
-                    "scope": "UNCHANGED",
-                    "confidentiality_impact": "HIGH",
-                    "integrity_impact": "HIGH",
-                    "availability_impact": "HIGH",
-                    "vector_string": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H",
-                },
-                "package_issue": {
-                    "affected_location": {
-                        "cpe_uri": "cpe:2.3:a:fasterxml:jackson-databind:*:*:*:*:*:*:*:*",
-                        "package": "jackson-databind",
-                        "version": ">=2.7.0-<2.9.10.8",
-                    },
-                    "fixed_location": "2.9.10.8",
-                },
-                "short_description": "FasterXML jackson-databind 2.x before 2.9.10.8 mishandles the interaction between serialization gadgets and typing, related to org.apache.commons.dbcp2.cpdsadapter.DriverAdapterCPDS.",
-                "long_description": None,
-                "related_urls": [
-                    "https://github.com/FasterXML/jackson-databind/issues/3004",
-                    "https://cowtowncoder.medium.com/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062",
-                ],
-                "effective_severity": "HIGH",
-                "source_update_time": "2023-09-13T14:56:00",
-                "source_orig_time": "2021-01-07T00:15:00",
-                "matched_by": "3647951461_3647986090|fasterxml|jackson-databind|2.9.6",
-            },
-            {
-                "id": "CVE-2019-12086",
-                "problem_type": "CWE-502",
-                "type": "fasterxml",
-                "severity": "HIGH",
-                "cvss_score": "7.5",
-                "cvss_v3": {
-                    "base_score": 7.5,
-                    "exploitability_score": 3.9,
-                    "impact_score": 3.6,
-                    "attack_vector": "NETWORK",
-                    "attack_complexity": "LOW",
-                    "privileges_required": "NONE",
-                    "user_interaction": "NONE",
-                    "scope": "UNCHANGED",
-                    "confidentiality_impact": "HIGH",
-                    "integrity_impact": "NONE",
-                    "availability_impact": "NONE",
-                    "vector_string": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
-                },
-                "package_issue": {
-                    "affected_location": {
-                        "cpe_uri": "cpe:2.3:a:fasterxml:jackson-databind:*:*:*:*:*:*:*:*",
-                        "package": "jackson-databind",
-                        "version": ">=2.9.0-<2.9.9",
-                    },
-                    "fixed_location": "2.9.9",
-                },
-                "short_description": "A Polymorphic Typing issue was discovered in FasterXML jackson-databind 2.x before 2.9.9. When Default Typing is enabled (either globally or for a specific property) for an externally exposed JSON endpoint, the service has the mysql-connector-java jar (8.0.14 or earlier) in the classpath, and an attacker can host a crafted MySQL server reachable by the victim, an attacker can send a crafted JSON message that allows them to read arbitrary local files on the server. This occurs because of missing com.mysql.cj.jdbc.admin.MiniAdmin validation.",
-                "long_description": None,
-                "related_urls": [
-                    "https://www.oracle.com/security-alerts/cpujul2020.html",
-                    "https://lists.apache.org/thread.html/rda99599896c3667f2cc9e9d34c7b6ef5d2bbed1f4801e1d75a2b0679@%3Ccommits.nifi.apache.org%3E",
-                    "https://www.oracle.com/security-alerts/cpuoct2020.html",
-                    "https://www.oracle.com/security-alerts/cpuApr2021.html",
-                    "https://www.oracle.com/security-alerts/cpuapr2022.html",
-                ],
-                "effective_severity": "HIGH",
-                "source_update_time": "2023-09-13T14:16:00",
-                "source_orig_time": "2019-05-17T17:29:00",
-                "matched_by": "3747044328_3747096861|fasterxml|jackson-databind|2.9.6",
-            },
-            {
-                "id": "CVE-2018-11784",
-                "problem_type": "CWE-601",
-                "type": "org.apache.tomcat.embed",
-                "severity": "MEDIUM",
-                "cvss_score": "4.3",
-                "cvss_v3": {
-                    "base_score": 4.3,
-                    "exploitability_score": 4.3,
-                    "impact_score": 4.3,
-                    "attack_vector": "NETWORK",
-                    "attack_complexity": "LOW",
-                    "privileges_required": "NONE",
-                    "user_interaction": "REQUIRED",
-                    "scope": "UNCHANGED",
-                    "confidentiality_impact": "MEDIUM",
-                    "integrity_impact": "MEDIUM",
-                    "availability_impact": "MEDIUM",
-                    "vector_string": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:N",
-                },
-                "package_issue": {
-                    "affected_location": {
-                        "cpe_uri": "cpe:2.3:a:org.apache.tomcat.embed:tomcat-embed-core:*:*:*:*:*:*:*:*",
-                        "package": "tomcat-embed-core",
-                        "version": ">=8.5.0-<8.5.34",
-                    },
-                    "fixed_location": "8.5.34",
-                },
-                "short_description": "# Moderate severity vulnerability that affects org.apache.tomcat.embed:tomcat-embed-core\nWhen the default servlet in Apache Tomcat versions 9.0.0.M1 to 9.0.11, 8.5.0 to 8.5.33 and 7.0.23 to 7.0.90 returned a redirect to a directory (e.g. redirecting to '/foo/' when the user requested '/foo') a specially crafted URL could be used to cause the redirect to be generated to any URI of the attackers choice.",
-                "long_description": None,
-                "related_urls": [
-                    "https://nvd.nist.gov/vuln/detail/CVE-2018-11784",
-                    "https://access.redhat.com/errata/RHSA-2019:0130",
-                    "https://access.redhat.com/errata/RHSA-2019:0131",
-                    "https://access.redhat.com/errata/RHSA-2019:0485",
-                    "https://access.redhat.com/errata/RHSA-2019:1529",
-                    "https://github.com/advisories/GHSA-5q99-f34m-67gc",
-                    "https://seclists.org/bugtraq/2019/Dec/43",
-                    "https://security.netapp.com/advisory/ntap-20181014-0002/",
-                ],
-                "effective_severity": "MEDIUM",
-                "source_update_time": "2023-04-11T01:35:23",
-                "source_orig_time": "2018-10-17T16:31:02",
-                "matched_by": "2650801486_2650849443|org.apache.tomcat.embed|tomcat-embed-core|8.5.31",
-            },
-            {
-                "id": "CVE-2022-22971",
-                "problem_type": "CWE-770",
-                "type": "org.springframework",
-                "severity": "MEDIUM",
-                "cvss_score": "6.5",
-                "cvss_v3": {
-                    "base_score": 6.5,
-                    "exploitability_score": 6.5,
-                    "impact_score": 6.5,
-                    "attack_vector": "NETWORK",
-                    "attack_complexity": "LOW",
-                    "privileges_required": "NONE",
-                    "user_interaction": "REQUIRED",
-                    "scope": "UNCHANGED",
-                    "confidentiality_impact": "MEDIUM",
-                    "integrity_impact": "MEDIUM",
-                    "availability_impact": "MEDIUM",
-                    "vector_string": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
-                },
-                "package_issue": {
-                    "affected_location": {
-                        "cpe_uri": "cpe:2.3:a:org.springframework:spring-core:*:*:*:*:*:*:*:*",
-                        "package": "spring-core",
-                        "version": ">=0-<5.2.22.RELEASE",
-                    },
-                    "fixed_location": "5.2.22.RELEASE",
-                },
-                "short_description": "# Allocation of Resources Without Limits or Throttling in Spring Framework\nIn spring framework versions prior to 5.3.20+ , 5.2.22+ and old unsupported versions, application with a STOMP over WebSocket endpoint is vulnerable to a denial of service attack by an authenticated user.",
-                "long_description": None,
-                "related_urls": [
-                    "https://nvd.nist.gov/vuln/detail/CVE-2022-22971",
-                    "https://security.netapp.com/advisory/ntap-20220616-0003/",
-                    "https://tanzu.vmware.com/security/cve-2022-22971",
-                    "https://www.oracle.com/security-alerts/cpujul2022.html",
-                ],
-                "effective_severity": "MEDIUM",
-                "source_update_time": "2023-04-11T01:33:53",
-                "source_orig_time": "2022-05-13T00:00:29",
-                "matched_by": "2660437234_2660469022|org.springframework|spring-core|5.0.7.RELEASE",
-            },
-            {
-                "id": "CVE-2022-40150",
-                "problem_type": "CWE-400,CWE-674",
-                "type": "org.codehaus.jettison",
-                "severity": "HIGH",
-                "cvss_score": "7.5",
-                "cvss_v3": {
-                    "base_score": 7.5,
-                    "exploitability_score": 7.5,
-                    "impact_score": 7.5,
-                    "attack_vector": "NETWORK",
-                    "attack_complexity": "LOW",
-                    "privileges_required": "NONE",
-                    "user_interaction": "REQUIRED",
-                    "scope": "UNCHANGED",
-                    "confidentiality_impact": "HIGH",
-                    "integrity_impact": "HIGH",
-                    "availability_impact": "HIGH",
-                    "vector_string": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
-                },
-                "package_issue": {
-                    "affected_location": {
-                        "cpe_uri": "cpe:2.3:a:org.codehaus.jettison:jettison:*:*:*:*:*:*:*:*",
-                        "package": "jettison",
-                        "version": ">=0-<1.5.2",
-                    },
-                    "fixed_location": "1.5.2",
-                },
-                "short_description": "# Jettison memory exhaustion\nThose using Jettison to parse untrusted XML or JSON data may be vulnerable to Denial of Service attacks (DOS). If the parser is running on user supplied input, an attacker may supply content that causes the parser to crash by Out of memory. This effect may support a denial of service attack.",
-                "long_description": None,
-                "related_urls": [
-                    "https://nvd.nist.gov/vuln/detail/CVE-2022-40150",
-                    "https://github.com/jettison-json/jettison/issues/45",
-                    "https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=46549",
-                    "https://github.com/jettison-json/jettison",
-                    "https://lists.debian.org/debian-lts-announce/2022/12/msg00045.html",
-                    "https://www.debian.org/security/2023/dsa-5312",
-                ],
-                "effective_severity": "HIGH",
-                "source_update_time": "2023-07-13T19:19:12",
-                "source_orig_time": "2022-09-17T00:00:41",
-                "matched_by": "2662034264_2662079740|org.codehaus.jettison|jettison|1.3.7",
-            },
-        ],
+        "vulnerabilities": [],
     }
     metadata = {
-        "depscan_version": "4.3.3",
+        "depscan_version": "5.0.2",
         "note": [
             {"audience": "", "category": "", "text": "", "title": ""},
             {"audience": "", "category": "", "text": "", "title": ""},
@@ -1032,14 +626,16 @@ def test_verify_components_present():
     assert template["document"]["notes"] == [
         {
             "category": "legal_disclaimer",
-            "text": "Depscan reachable code only covers the "
-            "project source code, not the code of "
-            "dependencies. A dependency may execute "
-            "vulnerable code when called even if it is "
-            "not in the project's source code. Regard the "
-            "Depscan-set flag of "
-            "'code_not_in_execute_path' with this in "
-            "mind.",
+            "text": (
+                "Depscan reachable code only covers the "
+                "project source code, not the code of "
+                "dependencies. A dependency may execute "
+                "vulnerable code when called even if it is "
+                "not in the project's source code. Regard the "
+                "Depscan-set flag of "
+                "'code_not_in_execute_path' with this in "
+                "mind."
+            ),
         }
     ]
     assert template["product_tree"] == {
@@ -1048,12 +644,12 @@ def test_verify_components_present():
                 "name": "vuln-spring",
                 "product_id": "vuln-spring:0.0.1-SNAPSHOT",
                 "product_identification_helper": {
-                    "purl": "pkg:maven/com.example/vuln-spring@0.0.1-SNAPSHOT?type=jar"
+                    "purl": "pkg:maven/com.example/vuln-spring@0.0.1-SNAPSHOT"
+                            "?type=jar"
                 },
             }
         ]
     }
-
     assert new_metadata["tracking"] == {
         "current_release_date": "2023-11-12T06:51:08",
         "id": "",
@@ -1064,7 +660,7 @@ def test_verify_components_present():
 
 
 def test_add_vulnerabilities():
-    data = {
+    template = {
         "document": {
             "aggregate_severity": {},
             "category": "csaf_vex",
@@ -1102,446 +698,338 @@ def test_add_vulnerabilities():
         "product_tree": None,
         "vulnerabilities": [],
     }
-    reached_purls = {
-        "pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@8.5.31"
-        "?type=jar": 3,
-        "pkg:maven/org.codehaus.jettison/jettison@1.3.7?type=jar": 19,
-    }
-    direct_purls = {}
-    results = [
+    pkg_vulnerabilities = [
         {
-            "id": "CVE-2020-36180",
-            "problem_type": "CWE-502",
-            "type": "fasterxml",
-            "severity": "UNKNOWN",
-            "cvss_score": "8.1",
-            "cvss_v3": {
-                "base_score": 8.1,
-                "exploitability_score": 2.2,
-                "impact_score": 5.9,
-                "attack_vector": "NETWORK",
-                "attack_complexity": "HIGH",
-                "privileges_required": "NONE",
-                "user_interaction": "NONE",
-                "scope": "UNCHANGED",
-                "confidentiality_impact": "HIGH",
-                "integrity_impact": "HIGH",
-                "availability_impact": "HIGH",
-                "vector_string": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            "bom-ref": "CVE-2020-10673/pkg:maven/com.fasterxml.jackson.core"
+                       "/jackson-databind@2.9.6?type=jar",
+            "id": "CVE-2020-10673",
+            "published": "2020-03-18T22:15:00",
+            "updated": "2023-11-07T03:14:00",
+            "source": {
+                "name": "NVD",
+                "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-10673",
             },
-            "package_issue": {
-                "affected_location": {
-                    "cpe_uri": "cpe:2.3:a:fasterxml:jackson-databind:*:*:*:*:*:*:*:*",
-                    "package": "jackson-databind",
-                    "version": ">=2.7.0-<2.9.10.8",
-                },
-                "fixed_location": "2.9.10.8",
-            },
-            "short_description": "FasterXML jackson-databind 2.x before 2.9.10.8 mishandles the interaction between serialization gadgets and typing, related to org.apache.commons.dbcp2.cpdsadapter.DriverAdapterCPDS.",
-            "long_description": None,
-            "related_urls": [
-                "https://github.com/FasterXML/jackson-databind/issues/3004",
-                "https://cowtowncoder.medium.com/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062",
+            "ratings": [
+                {"score": 8.8, "severity": "high", "method": "CVSSv31"}
             ],
-            "effective_severity": "HIGH",
-            "source_update_time": "2023-09-13T14:56:00",
-            "source_orig_time": "2021-01-07T00:15:00",
-            "matched_by": "3647951461_3647986090|fasterxml|jackson-databind|2.9.6",
+            "cwes": [668, 520, 521],
+            "description": (
+                "FasterXML jackson-databind 2.x before 2.9.10.4 mishandles the"
+                " interaction between serialization gadgets and typing, related"
+                " to com.caucho.config.types.ResourceRef (aka caucho-quercus)."
+            ),
+            "recommendation": "Update to 2.12.7.1 or later",
+            "advisories": [
+                {
+                    "title": "GitHub Issue",
+                    "url": "https://github.com/FasterXML/jackson-databind"
+                           "/issues/2660",
+                },
+                {
+                    "title": "Mailing List",
+                    "url": "https://lists.debian.org/debian-lts-announce/2020"
+                           "/03/msg00027.html",
+                },
+                {
+                    "title": "vendor",
+                    "url": (
+                        "https://www.oracle.com/security-alerts/cpuoct2021.html"
+                    ),
+                },
+            ],
+            "affects": [
+                {
+                    "ref": "pkg:maven/com.fasterxml.jackson.core/jackson"
+                           "-databind@2.9.6?type=jar",
+                    "versions": [
+                        {"version": "2.9.6", "status": "affected"},
+                        {"version": "2.12.7.1", "status": "unaffected"},
+                    ],
+                }
+            ],
+            "properties": [
+                {
+                    "name": "depscan:insights",
+                    "value": "Direct dependency\\nVendor Confirmed",
+                },
+                {"name": "depscan:prioritized", "value": "true"},
+                {"name": "cvssVersion", "value": "3.1"},
+                {"name": "cvssBaseScore", "value": 8.8},
+                {
+                    "name": "cvssVectorString",
+                    "value": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+                },
+                {"name": "cvssAttackVector", "value": "NETWORK"},
+                {"name": "cvssPrivilegesRequired", "value": "NONE"},
+                {"name": "cvssUserInteraction", "value": "REQUIRED"},
+                {"name": "cvssScope", "value": "UNCHANGED"},
+                {"name": "cvssBaseSeverity", "value": "HIGH"},
+                {
+                    "name": "affected_version_range",
+                    "value": ">=2.9.0-<2.9.10.4",
+                },
+            ],
         },
         {
-            "id": "CVE-2019-12086",
-            "problem_type": "CWE-502",
-            "type": "fasterxml",
-            "severity": "LOW",
-            "cvss_score": "7.5",
-            "cvss_v3": {
-                "base_score": 7.5,
-                "exploitability_score": 3.9,
-                "impact_score": 3.6,
-                "attack_vector": "NETWORK",
-                "attack_complexity": "LOW",
-                "privileges_required": "NONE",
-                "user_interaction": "NONE",
-                "scope": "UNCHANGED",
-                "confidentiality_impact": "HIGH",
-                "integrity_impact": "NONE",
-                "availability_impact": "NONE",
-                "vector_string": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+            "bom-ref": "CVE-2021-20190/pkg:maven/com.fasterxml.jackson.core"
+                       "/jackson-databind@2.9.6?type=jar",
+            "id": "CVE-2021-20190",
+            "published": "2021-01-19T17:15:00",
+            "updated": "2023-11-07T03:28:00",
+            "source": {
+                "name": "NVD",
+                "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-20190",
             },
-            "package_issue": {
-                "affected_location": {
-                    "cpe_uri": "cpe:2.3:a:fasterxml:jackson-databind:*:*:*:*:*:*:*:*",
-                    "package": "jackson-databind",
-                    "version": ">=2.9.0-<2.9.9",
-                },
-                "fixed_location": "2.9.9",
-            },
-            "short_description": "A Polymorphic Typing issue was discovered in FasterXML jackson-databind 2.x before 2.9.9. When Default Typing is enabled (either globally or for a specific property) for an externally exposed JSON endpoint, the service has the mysql-connector-java jar (8.0.14 or earlier) in the classpath, and an attacker can host a crafted MySQL server reachable by the victim, an attacker can send a crafted JSON message that allows them to read arbitrary local files on the server. This occurs because of missing com.mysql.cj.jdbc.admin.MiniAdmin validation.",
-            "long_description": None,
-            "related_urls": [
-                "https://www.oracle.com/security-alerts/cpujul2020.html",
-                "https://lists.apache.org/thread.html/rda99599896c3667f2cc9e9d34c7b6ef5d2bbed1f4801e1d75a2b0679@%3Ccommits.nifi.apache.org%3E",
-                "https://www.oracle.com/security-alerts/cpuoct2020.html",
-                "https://www.oracle.com/security-alerts/cpuApr2021.html",
-                "https://www.oracle.com/security-alerts/cpuapr2022.html",
+            "ratings": [
+                {"score": 8.1, "severity": "high", "method": "CVSSv31"}
             ],
-            "effective_severity": "HIGH",
-            "source_update_time": "2023-09-13T14:16:00",
-            "source_orig_time": "2019-05-17T17:29:00",
-            "matched_by": "3747044328_3747096861|fasterxml|jackson-databind|2.9.6",
-        },
-        {
-            "id": "CVE-2018-11784",
-            "problem_type": "CWE-601",
-            "type": "org.apache.tomcat.embed",
-            "severity": "MEDIUM",
-            "cvss_score": "4.3",
-            "cvss_v3": {
-                "base_score": 4.3,
-                "exploitability_score": 4.3,
-                "impact_score": 4.3,
-                "attack_vector": "NETWORK",
-                "attack_complexity": "LOW",
-                "privileges_required": "NONE",
-                "user_interaction": "REQUIRED",
-                "scope": "UNCHANGED",
-                "confidentiality_impact": "MEDIUM",
-                "integrity_impact": "MEDIUM",
-                "availability_impact": "MEDIUM",
-                "vector_string": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:N",
-            },
-            "package_issue": {
-                "affected_location": {
-                    "cpe_uri": "cpe:2.3:a:org.apache.tomcat.embed:tomcat-embed-core:*:*:*:*:*:*:*:*",
-                    "package": "tomcat-embed-core",
-                    "version": ">=8.5.0-<8.5.34",
+            "cwes": [502],
+            "description": (
+                "A flaw was found in jackson-databind before 2.9.10.7."
+                " FasterXML mishandles the interaction between serialization"
+                " gadgets and typing. The highest threat from this"
+                " vulnerability is to data confidentiality and integrity as"
+                " well as system availability."
+            ),
+            "recommendation": "Update to 2.12.7.1 or later",
+            "advisories": [
+                {
+                    "title": "GitHub Issue",
+                    "url": "https://github.com/FasterXML/jackson-databind"
+                           "/issues/2854",
                 },
-                "fixed_location": "8.5.34",
-            },
-            "short_description": "# Moderate severity vulnerability that affects org.apache.tomcat.embed:tomcat-embed-core\nWhen the default servlet in Apache Tomcat versions 9.0.0.M1 to 9.0.11, 8.5.0 to 8.5.33 and 7.0.23 to 7.0.90 returned a redirect to a directory (e.g. redirecting to '/foo/' when the user requested '/foo') a specially crafted URL could be used to cause the redirect to be generated to any URI of the attackers choice.",
-            "long_description": None,
-            "related_urls": [
-                "https://nvd.nist.gov/vuln/detail/CVE-2018-11784",
-                "https://access.redhat.com/errata/RHSA-2019:0130",
-                "https://access.redhat.com/errata/RHSA-2019:0131",
-                "https://access.redhat.com/errata/RHSA-2019:0485",
-                "https://access.redhat.com/errata/RHSA-2019:1529",
-                "https://github.com/advisories/GHSA-5q99-f34m-67gc",
-                "https://seclists.org/bugtraq/2019/Dec/43",
-                "https://security.netapp.com/advisory/ntap-20181014-0002/",
-            ],
-            "effective_severity": "MEDIUM",
-            "source_update_time": "2023-04-11T01:35:23",
-            "source_orig_time": "2018-10-17T16:31:02",
-            "matched_by": "2650801486_2650849443|org.apache.tomcat.embed|tomcat-embed-core|8.5.31",
-        },
-        {
-            "id": "CVE-2022-22971",
-            "problem_type": "CWE-770",
-            "type": "org.springframework",
-            "severity": "MEDIUM",
-            "cvss_score": "6.5",
-            "cvss_v3": {
-                "base_score": 6.5,
-                "exploitability_score": 6.5,
-                "impact_score": 6.5,
-                "attack_vector": "NETWORK",
-                "attack_complexity": "LOW",
-                "privileges_required": "NONE",
-                "user_interaction": "REQUIRED",
-                "scope": "UNCHANGED",
-                "confidentiality_impact": "MEDIUM",
-                "integrity_impact": "MEDIUM",
-                "availability_impact": "MEDIUM",
-                "vector_string": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
-            },
-            "package_issue": {
-                "affected_location": {
-                    "cpe_uri": "cpe:2.3:a:org.springframework:spring-core:*:*:*:*:*:*:*:*",
-                    "package": "spring-core",
-                    "version": ">=0-<5.2.22.RELEASE",
+                {
+                    "title": "vendor",
+                    "url": "https://www.oracle.com//security-alerts"
+                           "/cpujul2021.html",
                 },
-                "fixed_location": "5.2.22.RELEASE",
-            },
-            "short_description": "# Allocation of Resources Without Limits or Throttling in Spring Framework\nIn spring framework versions prior to 5.3.20+ , 5.2.22+ and old unsupported versions, application with a STOMP over WebSocket endpoint is vulnerable to a denial of service attack by an authenticated user.",
-            "long_description": None,
-            "related_urls": [
-                "https://nvd.nist.gov/vuln/detail/CVE-2022-22971",
-                "https://security.netapp.com/advisory/ntap-20220616-0003/",
-                "https://tanzu.vmware.com/security/cve-2022-22971",
-                "https://www.oracle.com/security-alerts/cpujul2022.html",
-            ],
-            "effective_severity": "MEDIUM",
-            "source_update_time": "2023-04-11T01:33:53",
-            "source_orig_time": "2022-05-13T00:00:29",
-            "matched_by": "2660437234_2660469022|org.springframework|spring-core|5.0.7.RELEASE",
-        },
-        {
-            "id": "CVE-2022-40150",
-            "problem_type": "CWE-400,CWE-674",
-            "type": "org.codehaus.jettison",
-            "severity": "LOW",
-            "cvss_score": "7.5",
-            "cvss_v3": {
-                "base_score": 7.5,
-                "exploitability_score": 7.5,
-                "impact_score": 7.5,
-                "attack_vector": "NETWORK",
-                "attack_complexity": "LOW",
-                "privileges_required": "NONE",
-                "user_interaction": "REQUIRED",
-                "scope": "UNCHANGED",
-                "confidentiality_impact": "HIGH",
-                "integrity_impact": "HIGH",
-                "availability_impact": "HIGH",
-                "vector_string": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
-            },
-            "package_issue": {
-                "affected_location": {
-                    "cpe_uri": "cpe:2.3:a:org.codehaus.jettison:jettison:*:*:*:*:*:*:*:*",
-                    "package": "jettison",
-                    "version": ">=0-<1.5.2",
+                {
+                    "title": "Mailing List",
+                    "url": "https://lists.debian.org/debian-lts-announce/2021"
+                           "/04/msg00025.html",
                 },
-                "fixed_location": "1.5.2",
-            },
-            "short_description": "# Jettison memory exhaustion\nThose using Jettison to parse untrusted XML or JSON data may be vulnerable to Denial of Service attacks (DOS). If the parser is running on user supplied input, an attacker may supply content that causes the parser to crash by Out of memory. This effect may support a denial of service attack.",
-            "long_description": None,
-            "related_urls": [
-                "https://nvd.nist.gov/vuln/detail/CVE-2022-40150",
-                "https://github.com/jettison-json/jettison/issues/45",
-                "https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=46549",
-                "https://github.com/jettison-json/jettison",
-                "https://lists.debian.org/debian-lts-announce/2022/12/msg00045.html",
-                "https://www.debian.org/security/2023/dsa-5312",
             ],
-            "effective_severity": "HIGH",
-            "source_update_time": "2023-07-13T19:19:12",
-            "source_orig_time": "2022-09-17T00:00:41",
-            "matched_by": "2662034264_2662079740|org.codehaus.jettison|jettison|1.3.7",
+            "affects": [
+                {
+                    "ref": "pkg:maven/com.fasterxml.jackson.core/jackson"
+                           "-databind@2.9.6?type=jar",
+                    "versions": [
+                        {"version": "2.9.6", "status": "affected"},
+                        {"version": "2.12.7.1", "status": "unaffected"},
+                    ],
+                }
+            ],
+            "properties": [
+                {
+                    "name": "depscan:insights",
+                    "value": "Direct dependency\\nVendor Confirmed",
+                },
+                {"name": "depscan:prioritized", "value": "true"},
+                {"name": "cvssVersion", "value": "3.1"},
+                {"name": "cvssBaseScore", "value": 8.1},
+                {
+                    "name": "cvssVectorString",
+                    "value": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H",
+                },
+                {"name": "cvssAttackVector", "value": "NETWORK"},
+                {"name": "cvssPrivilegesRequired", "value": "NONE"},
+                {"name": "cvssUserInteraction", "value": "NONE"},
+                {"name": "cvssScope", "value": "UNCHANGED"},
+                {"name": "cvssBaseSeverity", "value": "HIGH"},
+                {
+                    "name": "affected_version_range",
+                    "value": ">=2.7.0-<2.9.10.7",
+                },
+            ],
         },
     ]
-    new_results = add_vulnerabilities(
-        data, results, direct_purls, reached_purls
-    )
+    new_results = add_vulnerabilities(template, pkg_vulnerabilities)
 
-    assert new_results["document"]["aggregate_severity"].get("text") == "Medium"
-
-    assert new_results.get("vulnerabilities") == [{
-        'cve': 'CVE-2020-36180',
-        'cwe': {'id': 'CWE-502', 'name': 'Deserialization of Untrusted Data'},
-        'discovery_date': '2021-01-07T00:15:00',
-        'flags': [{'label': 'vulnerable_code_not_in_execute_path'}],
-        'ids': [{'system_name': 'GitHub Issue [FasterXML/jackson-databind]',
-                 'text': '3004'}],
-        'notes': [{'category': 'general',
-                   'details': 'Vulnerability Description',
-                   'text': 'FasterXML jackson-databind 2.x before 2.9.10.8 '
-                           'mishandles the interaction between serialization gadgets '
-                           'and typing, related to '
-                           'org.apache.commons.dbcp2.cpdsadapter.DriverAdapterCPDS.'}],
-        'product_status': {'fixed': ['jackson-databind:2.9.10.8'],
-                           'known_affected': ['jackson-databind:>=2.7.0-<2.9.10.8']},
-        'references': [{'summary': 'Other',
-                        'url': 'https://cowtowncoder.medium.com/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062'},
-                       {'summary': 'GitHub Issue',
-                        'url': 'https://github.com/FasterXML/jackson-databind/issues/3004'}]},
-        {'cve': 'CVE-2019-12086',
-         'cwe': {'id': 'CWE-502', 'name': 'Deserialization of Untrusted Data'},
-         'discovery_date': '2019-05-17T17:29:00',
-         'flags': [{'label': 'vulnerable_code_not_in_execute_path'}],
-         'ids': [],
-         'notes': [{'category': 'general',
-                    'details': 'Vulnerability Description',
-                    'text': 'A Polymorphic Typing issue was discovered in FasterXML '
-                            'jackson-databind 2.x before 2.9.9. When Default Typing '
-                            'is enabled (either globally or for a specific property) '
-                            'for an externally exposed JSON endpoint, the service has '
-                            'the mysql-connector-java jar (8.0.14 or earlier) in the '
-                            'classpath, and an attacker can host a crafted MySQL '
-                            'server reachable by the victim, an attacker can send a '
-                            'crafted JSON message that allows them to read arbitrary '
-                            'local files on the server. This occurs because of '
-                            'missing com.mysql.cj.jdbc.admin.MiniAdmin validation.'}],
-         'product_status': {'fixed': ['jackson-databind:2.9.9'],
-                            'known_affected': ['jackson-databind:>=2.9.0-<2.9.9']},
-         'references': [{'summary': 'Oracle Security Alert',
-                         'url': 'https://www.oracle.com/security-alerts/cpujul2020.html'},
-                        {'summary': 'Mailing List Other',
-                         'url': 'https://lists.apache.org/thread.html/rda99599896c3667f2cc9e9d34c7b6ef5d2bbed1f4801e1d75a2b0679@%3Ccommits.nifi.apache.org%3E'},
-                        {'summary': 'Oracle Security Alert',
-                         'url': 'https://www.oracle.com/security-alerts/cpuoct2020.html'},
-                        {'summary': 'Oracle Security Alert',
-                         'url': 'https://www.oracle.com/security-alerts/cpuApr2021.html'},
-                        {'summary': 'Oracle Security Alert',
-                         'url': 'https://www.oracle.com/security-alerts/cpuapr2022.html'}],
-         'scores': [{'cvss_v3': {'attackVector': 'NETWORK',
-                                 'baseScore': 7.5,
-                                 'baseSeverity': 'LOW',
-                                 'privilegesRequired': 'NONE',
-                                 'scope': 'UNCHANGED',
-                                 'userInteraction': 'NONE',
-                                 'vectorString': 'CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N',
-                                 'version': '3.1'},
-                     'products': ['jackson-databind']}]},
-        {'cve': 'CVE-2018-11784',
-         'cwe': {'id': 'CWE-601', 'name': 'URL Redirection to Untrusted Site'},
-         'discovery_date': '2018-10-17T16:31:02',
-         'ids': [{'system_name': 'GitHub Advisory', 'text': 'GHSA-5q99-f34m-67gc'},
-                 {'system_name': 'Red Hat Advisory', 'text': 'RHSA-2019:0130'},
-                 {'system_name': 'Red Hat Advisory', 'text': 'RHSA-2019:0131'},
-                 {'system_name': 'Red Hat Advisory', 'text': 'RHSA-2019:0485'},
-                 {'system_name': 'Red Hat Advisory', 'text': 'RHSA-2019:1529'},
-                 {'system_name': 'NetApp Advisory', 'text': 'ntap-20181014-0002'}],
-         'notes': [{'category': 'general',
-                    'details': 'Vulnerability Description',
-                    'text': '# Moderate severity vulnerability that affects '
-                            'org.apache.tomcat.embed:tomcat-embed-core When the '
-                            'default servlet in Apache Tomcat versions 9.0.0.M1 to '
-                            '9.0.11, 8.5.0 to 8.5.33 and 7.0.23 to 7.0.90 returned a '
-                            "redirect to a directory (e.g. redirecting to '/foo/' "
-                            "when the user requested '/foo') a specially crafted URL "
-                            'could be used to cause the redirect to be generated to '
-                            'any URI of the attackers choice.'}],
-         'product_status': {'fixed': ['tomcat-embed-core:8.5.34'],
-                            'known_affected': ['tomcat-embed-core:>=8.5.0-<8.5.34']},
-         'references': [{'summary': 'CVE Record',
-                         'url': 'https://nvd.nist.gov/vuln/detail/CVE-2018-11784'},
-                        {'summary': 'Other',
-                         'url': 'https://seclists.org/bugtraq/2019/Dec/43'},
-                        {'summary': 'Red Hat Advisory',
-                         'url': 'https://access.redhat.com/errata/RHSA-2019:0130'},
-                        {'summary': 'Red Hat Advisory',
-                         'url': 'https://access.redhat.com/errata/RHSA-2019:0131'},
-                        {'summary': 'Red Hat Advisory',
-                         'url': 'https://access.redhat.com/errata/RHSA-2019:0485'},
-                        {'summary': 'Red Hat Advisory',
-                         'url': 'https://access.redhat.com/errata/RHSA-2019:1529'},
-                        {'summary': 'GitHub Advisory',
-                         'url': 'https://github.com/advisories/GHSA-5q99-f34m-67gc'},
-                        {'summary': 'NetApp Advisory',
-                         'url': 'https://security.netapp.com/advisory/ntap-20181014-0002/'}],
-         'scores': [{'cvss_v3': {'attackVector': 'NETWORK',
-                                 'baseScore': 4.3,
-                                 'baseSeverity': 'MEDIUM',
-                                 'privilegesRequired': 'NONE',
-                                 'scope': 'UNCHANGED',
-                                 'userInteraction': 'REQUIRED',
-                                 'vectorString': 'CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:N',
-                                 'version': '3.0'},
-                     'products': ['tomcat-embed-core']}]},
-        {'cve': 'CVE-2022-22971',
-         'cwe': {'id': 'CWE-770',
-                 'name': 'Allocation of Resources Without Limits or Throttling'},
-         'discovery_date': '2022-05-13T00:00:29',
-         'flags': [{'label': 'vulnerable_code_not_in_execute_path'}],
-         'ids': [{'system_name': 'NetApp Advisory', 'text': 'ntap-20220616-0003'}],
-         'notes': [{'category': 'general',
-                    'details': 'Vulnerability Description',
-                    'text': '# Allocation of Resources Without Limits or Throttling '
-                            'in Spring Framework In spring framework versions prior '
-                            'to 5.3.20+ , 5.2.22+ and old unsupported versions, '
-                            'application with a STOMP over WebSocket endpoint is '
-                            'vulnerable to a denial of service attack by an '
-                            'authenticated user.'}],
-         'product_status': {'fixed': ['spring-core:5.2.22.RELEASE'],
-                            'known_affected': ['spring-core:>=0-<5.2.22.RELEASE']},
-         'references': [{'summary': 'CVE Record',
-                         'url': 'https://nvd.nist.gov/vuln/detail/CVE-2022-22971'},
-                        {'summary': 'CVE Record',
-                         'url': 'https://tanzu.vmware.com/security/cve-2022-22971'},
-                        {'summary': 'Oracle Security Alert',
-                         'url': 'https://www.oracle.com/security-alerts/cpujul2022.html'},
-                        {'summary': 'NetApp Advisory',
-                         'url': 'https://security.netapp.com/advisory/ntap-20220616-0003/'}],
-         'scores': [{'cvss_v3': {'attackVector': 'NETWORK',
-                                 'baseScore': 6.5,
-                                 'baseSeverity': 'MEDIUM',
-                                 'privilegesRequired': 'NONE',
-                                 'scope': 'UNCHANGED',
-                                 'userInteraction': 'REQUIRED',
-                                 'vectorString': 'CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H',
-                                 'version': '3.1'},
-                     'products': ['spring-core']}]},
-        {'cve': 'CVE-2022-40150',
-         'cwe': {'id': 'CWE-400', 'name': 'Uncontrolled Resource Consumption'},
-         'discovery_date': '2022-09-17T00:00:41',
-         'ids': [{'system_name': 'GitHub Issue [jettison-json/jettison]',
-                  'text': '45'},
-                 {'system_name': 'Chromium Issue [oss-fuzz]', 'text': '46549'},
-                 {'system_name': 'Debian Advisory', 'text': 'dsa-5312'}],
-         'notes': [{'audience': 'developers',
-                    'category': 'other',
-                    'text': 'Uncontrolled Recursion',
-                    'title': 'Additional CWE: CWE-674'},
-                   {'category': 'general',
-                    'details': 'Vulnerability Description',
-                    'text': '# Jettison memory exhaustion Those using Jettison to '
-                            'parse untrusted XML or JSON data may be vulnerable to '
-                            'Denial of Service attacks (DOS). If the parser is '
-                            'running on user supplied input, an attacker may supply '
-                            'content that causes the parser to crash by Out of '
-                            'memory. This effect may support a denial of service '
-                            'attack.'}],
-         'product_status': {'fixed': ['jettison:1.5.2'],
-                            'known_affected': ['jettison:>=0-<1.5.2']},
-         'references': [{'summary': 'CVE Record',
-                         'url': 'https://nvd.nist.gov/vuln/detail/CVE-2022-40150'},
-                        {'summary': 'GitHub Repository',
-                         'url': 'https://github.com/jettison-json/jettison'},
-                        {'summary': 'Mailing List Announcement',
-                         'url': 'https://lists.debian.org/debian-lts-announce/2022/12/msg00045.html'},
-                        {'summary': 'GitHub Issue',
-                         'url': 'https://github.com/jettison-json/jettison/issues/45'},
-                        {'summary': 'Chromium Issue',
-                         'url': 'https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=46549'},
-                        {'summary': 'Debian Advisory',
-                         'url': 'https://www.debian.org/security/2023/dsa-5312'}],
-         'scores': [{'cvss_v3': {'attackVector': 'NETWORK',
-                                 'baseScore': 7.5,
-                                 'baseSeverity': 'LOW',
-                                 'privilegesRequired': 'NONE',
-                                 'scope': 'UNCHANGED',
-                                 'userInteraction': 'REQUIRED',
-                                 'vectorString': 'CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H',
-                                 'version': '3.1'},
-                     'products': ['jettison']}]}
-                                                  ]
+    assert new_results.get("vulnerabilities") == [
+        {
+            "acknowledgements": {
+                "organization": "NVD",
+                "urls": ["https://nvd.nist.gov/vuln/detail/CVE-2020-10673"],
+            },
+            "cve": "CVE-2020-10673",
+            "cwe": {
+                "id": "668",
+                "name": "Exposure of Resource to Wrong Sphere",
+            },
+            "discovery_date": "2020-03-18T22:15:00",
+            "ids": [
+                {
+                    "system_name": "GitHub Issue [FasterXML/jackson-databind]",
+                    "text": "2660",
+                }
+            ],
+            "notes": [
+                {
+                    "audience": "developers",
+                    "category": "other",
+                    "text": ".NET Misconfiguration: Use of Impersonation",
+                    "title": "Additional CWE: 520",
+                },
+                {
+                    "audience": "developers",
+                    "category": "other",
+                    "text": "Weak Password Requirements",
+                    "title": "Additional CWE: 521",
+                },
+                {
+                    "category": "general",
+                    "details": "Vulnerability Description",
+                    "text": (
+                        "FasterXML jackson-databind 2.x before 2.9.10.4"
+                        " mishandles the interaction between serialization"
+                        " gadgets and typing, related to"
+                        " com.caucho.config.types.ResourceRef (aka"
+                        " caucho-quercus)."
+                    ),
+                },
+            ],
+            "product_status": {
+                "fixed": [
+                    "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2"
+                    ".12.7.1?type=jar"
+                ],
+                "known_affected": [
+                    "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2"
+                    ".9.6?type=jar"
+                ],
+            },
+            "references": [
+                {
+                    "summary": "Mailing List Announcement",
+                    "url": "https://lists.debian.org/debian-lts-announce/2020"
+                           "/03/msg00027.html",
+                },
+                {
+                    "summary": "Oracle Security Alert",
+                    "url": (
+                        "https://www.oracle.com/security-alerts/cpuoct2021.html"
+                    ),
+                },
+                {
+                    "summary": "GitHub Issue",
+                    "url": "https://github.com/FasterXML/jackson-databind"
+                           "/issues/2660",
+                },
+            ],
+            "scores": [
+                {
+                    "cvss_v3": {
+                        "attackVector": "NETWORK",
+                        "baseScore": 8.8,
+                        "baseSeverity": "HIGH",
+                        "privilegesRequired": "NONE",
+                        "scope": "UNCHANGED",
+                        "userInteraction": "REQUIRED",
+                        "vectorString": (
+                            "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H"
+                        ),
+                        "version": "3.1",
+                    },
+                    "products": [
+                        "pkg:maven/com.fasterxml.jackson.core/jackson"
+                        "-databind@2.9.6?type=jar"
+                    ],
+                }
+            ],
+        },
+        {
+            "acknowledgements": {
+                "organization": "NVD",
+                "urls": ["https://nvd.nist.gov/vuln/detail/CVE-2021-20190"],
+            },
+            "cve": "CVE-2021-20190",
+            "cwe": {"id": "502", "name": "Deserialization of Untrusted Data"},
+            "discovery_date": "2021-01-19T17:15:00",
+            "ids": [
+                {
+                    "system_name": "GitHub Issue [FasterXML/jackson-databind]",
+                    "text": "2854",
+                }
+            ],
+            "notes": [
+                {
+                    "category": "general",
+                    "details": "Vulnerability Description",
+                    "text": (
+                        "A flaw was found in jackson-databind before "
+                        "2.9.10.7. FasterXML mishandles the interaction "
+                        "between serialization gadgets and typing. The "
+                        "highest threat from this vulnerability is to "
+                        "data confidentiality and integrity as well as "
+                        "system availability."
+                    ),
+                }
+            ],
+            "product_status": {
+                "fixed": [
+                    "pkg:maven/com.fasterxml.jackson.core/jackson"
+                    "-databind@2.12.7.1?type=jar"
+                ],
+                "known_affected": [
+                    "pkg:maven/com.fasterxml.jackson.core"
+                    "/jackson-databind@2.9.6?type=jar"
+                ],
+            },
+            "references": [
+                {
+                    "summary": "Other",
+                    "url": (
+                        "https://www.oracle.com//security-alerts"
+                        "/cpujul2021.html"
+                    ),
+                },
+                {
+                    "summary": "Mailing List Announcement",
+                    "url": (
+                        "https://lists.debian.org/debian-lts-announce/2021"
+                        "/04/msg00025.html"
+                    ),
+                },
+                {
+                    "summary": "GitHub Issue",
+                    "url": (
+                        "https://github.com/FasterXML/jackson-databind"
+                        "/issues/2854"
+                    ),
+                },
+            ],
+            "scores": [
+                {
+                    "cvss_v3": {
+                        "attackVector": "NETWORK",
+                        "baseScore": 8.1,
+                        "baseSeverity": "HIGH",
+                        "privilegesRequired": "NONE",
+                        "scope": "UNCHANGED",
+                        "userInteraction": "NONE",
+                        "vectorString": (
+                            "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
+                        ),
+                        "version": "3.1",
+                    },
+                    "products": [
+                        "pkg:maven/com.fasterxml.jackson.core"
+                        "/jackson-databind@2.9.6?type=jar"
+                    ],
+                }
+            ],
+        },
+    ]
 
 
-def test_version_helper():
-    # Returns True if the version in 'reached' satisfies the conditions
-    # specified by 'vdata'.
-    reached = ["1.0.0", "2.0.0", "3.0.0"]
-    vdata = {"lower": "2.0.0", "lmod": ">=", "upper": "3.0.0", "umod": "<"}
-    result = version_helper(reached, vdata)
-    assert result is True
-
-    # Returns False if the version in 'reached' does not satisfy the
-    # conditions specified by 'vdata'.
-    vdata = {"lower": "4.0.0", "lmod": ">=", "upper": "5.0.0", "umod": "<"}
-    result = version_helper(reached, vdata)
-    assert result is False
-
-    # Returns True if the lower bound modifier is ">=" and the version in
-    # 'reached' is equal to the lower bound of the version range.
-    vdata = {"lower": "2.0.0", "lmod": ">=", "upper": "3.0.0", "umod": "<"}
-    result = version_helper(reached, vdata)
-    assert result is True
-
-    # Returns False if the lower bound modifier is ">=" and the version in
-    # 'reached' is less than the lower bound of the version range.
-    vdata = {"lower": "4.0.0", "lmod": ">=", "upper": "5.0.0", "umod": "<"}
-    result = version_helper(reached, vdata)
-    assert result is False
-
-    # Returns False if the upper bound modifier is "<=" and the version in
-    # 'reached' is greater than the upper bound of the version range.
-    vdata = {"lower": "2.0.0", "lmod": ">=", "upper": "3.0.0", "umod": "<="}
-    result = version_helper(reached, vdata)
-    assert result is True
-
-    #  Returns False if the lower bound modifier is ">" and the version in
-    # 'reached' is less than or equal to the lower bound of the version range.
-    vdata = {"lower": "2.0.0", "lmod": ">", "upper": "3.0.0", "umod": "<"}
-    result = version_helper(reached, vdata)
-    assert result is False
+def test_get_acknowledgements():
+    source = {
+        "name": "NVD",
+        "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-20190",
+    }
+    assert get_acknowledgements(source) == {
+        "organization": "NVD",
+        "urls": ["https://nvd.nist.gov/vuln/detail/CVE-2021-20190"],
+    }
+    source = {"url": "https://nvd.nist.gov/vuln/detail/CVE-2021-20190"}
+    assert get_acknowledgements(source) is None

--- a/test/test_csaf.py
+++ b/test/test_csaf.py
@@ -429,40 +429,33 @@ def test_parse_toml():
 
 
 def test_parse_cvss():
-    props = [
-        {"name": "cvssVersion", "value": "3.0"},
-        {"name": "cvssBaseScore", "value": 9.8},
-        {
-            "name": "cvssVectorString",
-            "value": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
-        },
-        {"name": "cvssPrivilegesRequired", "value": "NONE"},
-        {"name": "cvssUserInteraction", "value": "NONE"},
-        {"name": "cvssScope", "value": "UNCHANGED"},
-        {"name": "cvssBaseSeverity", "value": "CRITICAL"},
-        {"name": "affectedVersionRange", "value": ">=2.9.0-<2.9.8"},
-    ]
-    assert parse_cvss(props) == {
-        "baseScore": 9.8,
-        "baseSeverity": "CRITICAL",
-        "privilegesRequired": "NONE",
-        "scope": "UNCHANGED",
-        "userInteraction": "NONE",
-        "vectorString": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
-        "version": "3.0",
+    assert parse_cvss([{
+        "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"}]) == {
+        'attackComplexity': 'LOW',
+        'attackVector': 'NETWORK',
+        'availabilityImpact': 'HIGH',
+        'baseScore': 9.8,
+        'baseSeverity': 'CRITICAL',
+        'confidentialityImpact': 'HIGH',
+        'environmentalScore': 9.8,
+        'environmentalSeverity': 'CRITICAL',
+        'integrityImpact': 'HIGH',
+        'modifiedAttackComplexity': 'LOW',
+        'modifiedAttackVector': 'NETWORK',
+        'modifiedAvailabilityImpact': 'HIGH',
+        'modifiedConfidentialityImpact': 'HIGH',
+        'modifiedIntegrityImpact': 'HIGH',
+        'modifiedPrivilegesRequired': 'NONE',
+        'modifiedUserInteraction': 'NONE',
+        'privilegesRequired': 'NONE',
+        'scope': 'UNCHANGED',
+        'temporalScore': 9.8,
+        'temporalSeverity': 'CRITICAL',
+        'userInteraction': 'NONE',
+        'vectorString': 'CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H',
+        'version': '3.0'
     }
-    props.append({"name": "cvssAttackVector", "value": "NETWORK"},)
-    assert parse_cvss(props) == {
-        "attackVector": "NETWORK",
-        "baseScore": 9.8,
-        "baseSeverity": "CRITICAL",
-        "privilegesRequired": "NONE",
-        "scope": "UNCHANGED",
-        "userInteraction": "NONE",
-        "vectorString": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
-        "version": "3.0",
-    }
-    assert parse_cvss([]) == {}
+    assert parse_cvss([{}]) == {}
 
 
 def test_get_products():
@@ -723,7 +716,12 @@ def test_add_vulnerabilities():
                 "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-10673",
             },
             "ratings": [
-                {"score": 8.8, "severity": "high", "method": "CVSSv31"}
+                {
+                    "score": 8.8,
+                    "severity": "high",
+                    "method": "CVSSv31",
+                    "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H"
+                }
             ],
             "cwes": [668, 520, 521],
             "description": (
@@ -766,17 +764,6 @@ def test_add_vulnerabilities():
                     "value": "Direct dependency\\nVendor Confirmed",
                 },
                 {"name": "depscan:prioritized", "value": "true"},
-                {"name": "cvssVersion", "value": "3.1"},
-                {"name": "cvssBaseScore", "value": 8.8},
-                {
-                    "name": "cvssVectorString",
-                    "value": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
-                },
-                {"name": "cvssAttackVector", "value": "NETWORK"},
-                {"name": "cvssPrivilegesRequired", "value": "NONE"},
-                {"name": "cvssUserInteraction", "value": "REQUIRED"},
-                {"name": "cvssScope", "value": "UNCHANGED"},
-                {"name": "cvssBaseSeverity", "value": "HIGH"},
                 {
                     "name": "affected_version_range",
                     "value": ">=2.9.0-<2.9.10.4",
@@ -794,7 +781,12 @@ def test_add_vulnerabilities():
                 "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-20190",
             },
             "ratings": [
-                {"score": 8.1, "severity": "high", "method": "CVSSv31"}
+                {
+                    "score": 8.1,
+                    "severity": "high",
+                    "method": "CVSSv31",
+                    "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
+                }
             ],
             "cwes": [502],
             "description": (
@@ -838,17 +830,6 @@ def test_add_vulnerabilities():
                     "value": "Direct dependency\\nVendor Confirmed",
                 },
                 {"name": "depscan:prioritized", "value": "true"},
-                {"name": "cvssVersion", "value": "3.1"},
-                {"name": "cvssBaseScore", "value": 8.1},
-                {
-                    "name": "cvssVectorString",
-                    "value": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H",
-                },
-                {"name": "cvssAttackVector", "value": "NETWORK"},
-                {"name": "cvssPrivilegesRequired", "value": "NONE"},
-                {"name": "cvssUserInteraction", "value": "NONE"},
-                {"name": "cvssScope", "value": "UNCHANGED"},
-                {"name": "cvssBaseSeverity", "value": "HIGH"},
                 {
                     "name": "affected_version_range",
                     "value": ">=2.7.0-<2.9.10.7",
@@ -927,19 +908,32 @@ def test_add_vulnerabilities():
                 },
             ],
             "scores": [
-                {
-                    "cvss_v3": {
-                        "attackVector": "NETWORK",
-                        "baseScore": 8.8,
-                        "baseSeverity": "HIGH",
-                        "privilegesRequired": "NONE",
-                        "scope": "UNCHANGED",
-                        "userInteraction": "REQUIRED",
-                        "vectorString": (
-                            "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H"
-                        ),
-                        "version": "3.1",
-                    },
+                {'cvss_v3': {
+                    'attackComplexity': 'LOW',
+                    'attackVector': 'NETWORK',
+                    'availabilityImpact': 'HIGH',
+                    'baseScore': 8.8,
+                    'baseSeverity': 'HIGH',
+                    'confidentialityImpact': 'HIGH',
+                    'environmentalScore': 8.8,
+                    'environmentalSeverity': 'HIGH',
+                    'integrityImpact': 'HIGH',
+                    'modifiedAttackComplexity': 'LOW',
+                    'modifiedAttackVector': 'NETWORK',
+                    'modifiedAvailabilityImpact': 'HIGH',
+                    'modifiedConfidentialityImpact': 'HIGH',
+                    'modifiedIntegrityImpact': 'HIGH',
+                    'modifiedPrivilegesRequired': 'NONE',
+                    'modifiedUserInteraction': 'REQUIRED',
+                    'privilegesRequired': 'NONE',
+                    'scope': 'UNCHANGED',
+                    'temporalScore': 8.8,
+                    'temporalSeverity': 'HIGH',
+                    'userInteraction': 'REQUIRED',
+                    'vectorString': 'CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H'
+                                    '/A:H',
+                    'version': '3.1'
+                },
                     "products": [
                         "com.fasterxml.jackson.core/jackson-databind@2.9.6"
                     ],
@@ -1007,17 +1001,31 @@ def test_add_vulnerabilities():
             ],
             "scores": [
                 {
-                    "cvss_v3": {
-                        "attackVector": "NETWORK",
-                        "baseScore": 8.1,
-                        "baseSeverity": "HIGH",
-                        "privilegesRequired": "NONE",
-                        "scope": "UNCHANGED",
-                        "userInteraction": "NONE",
-                        "vectorString": (
-                            "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
-                        ),
-                        "version": "3.1",
+                    'cvss_v3': {
+                        'attackComplexity': 'HIGH',
+                        'attackVector': 'NETWORK',
+                        'availabilityImpact': 'HIGH',
+                        'baseScore': 8.1,
+                        'baseSeverity': 'HIGH',
+                        'confidentialityImpact': 'HIGH',
+                        'environmentalScore': 8.1,
+                        'environmentalSeverity': 'HIGH',
+                        'integrityImpact': 'HIGH',
+                        'modifiedAttackComplexity': 'HIGH',
+                        'modifiedAttackVector': 'NETWORK',
+                        'modifiedAvailabilityImpact': 'HIGH',
+                        'modifiedConfidentialityImpact': 'HIGH',
+                        'modifiedIntegrityImpact': 'HIGH',
+                        'modifiedPrivilegesRequired': 'NONE',
+                        'modifiedUserInteraction': 'NONE',
+                        'privilegesRequired': 'NONE',
+                        'scope': 'UNCHANGED',
+                        'temporalScore': 8.1,
+                        'temporalSeverity': 'HIGH',
+                        'userInteraction': 'NONE',
+                        'vectorString': 'CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H'
+                                        '/I:H/A:H',
+                        'version': '3.1'
                     },
                     "products": [
                         "com.fasterxml.jackson.core/jackson-databind@2.9.6"
@@ -1026,33 +1034,6 @@ def test_add_vulnerabilities():
             ],
         },
     ]
-    pkg_vulnerabilities[1]["source"] = {}
-    pkg_vulnerabilities[1]["affects"] = []
-    pkg_vulnerabilities[1]["properties"] = []
-    pkg_vulnerabilities[1]["advisories"] = []
-    new_results = add_vulnerabilities(template, pkg_vulnerabilities)
-    assert new_results.get("vulnerabilities")[1] == {
-        'acknowledgements': {},
-        'cve': 'CVE-2021-20190',
-        'cwe': {'id': '502', 'name': 'Deserialization of Untrusted Data'},
-        'discovery_date': '2021-01-19T17:15:00',
-        'ids': [],
-        'notes': [{'category': 'general',
-                   'details': 'Vulnerability Description',
-                   'text': 'A flaw was found in jackson-databind before '
-                           '2.9.10.7. FasterXML mishandles the interaction '
-                           'between serialization gadgets and typing. The '
-                           'highest threat from this vulnerability is to data '
-                           'confidentiality and integrity as well as system '
-                           'availability.'}],
-        'product_status': {},
-        'references': [],
-        'scores': [{'cvss_v3': {}, 'products': []}]}
-    assert new_results.get("vulnerabilities")[1]["acknowledgements"] == {}
-    assert new_results.get("vulnerabilities")[1]["product_status"] == {}
-    assert new_results.get("vulnerabilities")[1]["scores"] == [
-        {'cvss_v3': {}, 'products': []}]
-
     new_results = add_vulnerabilities(template, [])
     assert new_results.get("vulnerabilities") == []
 


### PR DESCRIPTION
## Changes

### Reuse `pkg_vulnerabilities` list produced by `prepare_vdr()` instead of `results` list.
- Added full CVSS scoring to properties of pkg_vulnerabilities objects with function `cvss_to_vdr()`
- If the CVSS vector string indicates the version is 3.0 rather than the default 3.1, updates this in `pkg_vulnerabilities` objects
- Added date metadata where available to the published and updated fields of `pkg_vulnerabilities` objects for use in csaf
- Parse CWEs so that multiple CWEs can be listed in the vdr (csaf will continue to add extra CWEs to notes) with `split_cwe()` function
- Reverted to using `bom_file` rather than `vdr_file` for `import_root_component` as a csaf does not need to have a vulnerability section to be valid, but no vulnerabilities means there will be no vdr_file.
- Added source providing the vulnerability data to csaf vulnerability acknowledgement

### Miscellaneous csaf.py
- Replaced the `CSAFOccurence` class with the `vdr_to_csaf()` function
- Corrected docstrings and converted to restructuredText format to match the rest of depscan