### PR TITLE
Search by purl. Also fixes #185

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,22 +108,26 @@ Use the `/scan` endpoint to perform scans.
 > [!NOTE]
 > The `type` parameter is mandatory in server mode.
 
-* Scanning a local directory.
+- Scanning a local directory.
+
 ```bash
 curl --json '{"path": "/tmp/vulnerable-aws-koa-app", "type": "js"}' http://0.0.0.0:7070/scan
 ```
 
-* Scanning a SBOM file (present locally).
+- Scanning a SBOM file (present locally).
+
 ```bash
 curl --json '{"path": "/tmp/vulnerable-aws-koa-app/sbom_file.json", "type": "js"}' http://0.0.0.0:7070/scan
 ```
 
-* Scanning a GitHub repo.
+- Scanning a GitHub repo.
+
 ```bash
 curl --json '{"url": "https://github.com/HooliCorp/vulnerable-aws-koa-app", "type": "js"}' http://0.0.0.0:7070/scan -o app.vdr.json
 ```
 
-* Uploading a SBOM file and generating results based on it.
+- Uploading a SBOM file and generating results based on it.
+
 ```bash
 curl -X POST -H 'Content-Type: multipart/form-data' -F 'file=@/tmp/app/sbom_file.json' http://0.0.0.0:7070/scan?type=js
 ```
@@ -203,6 +207,7 @@ options:
   --explain             Makes depscan to explain the various analysis. Useful for creating detailed reports.
   --reachables-slices-file REACHABLES_SLICES_FILE
                         Path for the reachables slices file created by atom.
+  --purl SEARCH_PURL    Scan a single package url.
   -v, --version         Display the version
 ```
 

--- a/depscan/lib/audit.py
+++ b/depscan/lib/audit.py
@@ -4,14 +4,16 @@ from depscan.lib import config
 from depscan.lib.pkg_query import npm_metadata, pypi_metadata
 
 # Dict mapping project type to the audit source
-type_audit_map = {"nodejs": NpmSource(), "js": NpmSource()}
+type_audit_map = {"nodejs": NpmSource(), "js": NpmSource(), "npm": NpmSource()}
 
 # Dict mapping project type to risk audit
 risk_audit_map = {
+    "npm": npm_metadata,
     "nodejs": npm_metadata,
     "js": npm_metadata,
     "python": pypi_metadata,
     "py": pypi_metadata,
+    "pypi": pypi_metadata,
 }
 
 

--- a/depscan/lib/csaf.py
+++ b/depscan/lib/csaf.py
@@ -1577,6 +1577,7 @@ def parse_toml(metadata):
         'current_release_date'.
     """
     tracking = parse_revision_history(metadata.get("tracking"))
+    # FIXME: Could this be simplified as list comprehension without append
     refs = []
     [refs.append(v) for v in metadata.get("reference")]
     notes = []

--- a/depscan/lib/normalize.py
+++ b/depscan/lib/normalize.py
@@ -54,10 +54,10 @@ def create_pkg_variations(pkg_dict):
             if purl_obj:
                 pkg_type = purl_obj.get("type")
                 qualifiers = purl_obj.get("qualifiers", {})
-                if qualifiers.get("distro_name"):
+                if qualifiers and qualifiers.get("distro_name"):
                     os_distro_name = qualifiers.get("distro_name")
                     name_aliases.add(f"""{os_distro_name}/{name}""")
-                if qualifiers.get("distro"):
+                if qualifiers and qualifiers.get("distro"):
                     os_distro = qualifiers.get("distro")
                     name_aliases.add(f"""{os_distro}/{name}""")
                     # almalinux-9.2 becomes almalinux-9
@@ -70,6 +70,7 @@ def create_pkg_variations(pkg_dict):
     if vendor:
         vendor_aliases.add(vendor)
         vendor_aliases.add(vendor.lower())
+        vendor_aliases.add(vendor.lstrip("@"))
         if (
             vendor.startswith("org.")
             or vendor.startswith("io.")
@@ -94,7 +95,6 @@ def create_pkg_variations(pkg_dict):
             vendor_aliases.add("golang")
     if pkg_type not in config.OS_PKG_TYPES:
         name_aliases.add("package_" + name)
-        vendor_aliases.add(pkg_type)
         if purl.startswith("pkg:composer"):
             vendor_aliases.add("get" + name)
             vendor_aliases.add(name + "_project")
@@ -168,7 +168,7 @@ def create_pkg_variations(pkg_dict):
             name_aliases.add(name + "-bin")
     else:
         # Filter vendor aliases that are also name aliases
-        vendor_aliases = [x for x in vendor_aliases if x not in name_aliases]
+        vendor_aliases = [x for x in vendor_aliases if x not in name_aliases or x == vendor]
     if len(vendor_aliases) > 0:
         for vvar in list(vendor_aliases):
             for nvar in list(name_aliases):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "owasp-depscan"
-version = "5.0.2"
+version = "5.0.3"
 description = "Fully open-source security audit for project dependencies based on known vulnerabilities and advisories."
 authors = [
     {name = "Team AppThreat", email = "cloud@appthreat.com"},
 ]
 dependencies = [
-    "appthreat-vulnerability-db>=5.5.4",
+    "appthreat-vulnerability-db>=5.5.5",
     "defusedxml",
     "oras",
     "PyYAML",


### PR DESCRIPTION
Sample execution

```
PYTHONPATH=. python depscan/cli.py --purl "pkg:npm/%40colors/colors@1.5.0" --reports-dir /tmp/reports
```

Without this PR, [CVE-2021-23567](https://nvd.nist.gov/vuln/detail/CVE-2021-23567) was incorrectly surfaced as a CVE.

## Todo

- [x] vdb appears to be broken due to cvss_v3 being None. Fixed.
- [x] There is 1 test related to csaf which is failing. Working on a fix.

cc: @mayaa23 