### PR TITLE
Trim aliasing for vendorless packages

### DIFF
--- a/depscan/lib/normalize.py
+++ b/depscan/lib/normalize.py
@@ -155,10 +155,12 @@ def create_pkg_variations(pkg_dict):
         for suffix in COMMON_SUFFIXES:
             if name.endswith(suffix):
                 name_aliases.add(name.replace(suffix, ""))
-        for k, v in config.package_alias.items():
-            if name.startswith(k) or k.startswith(name) or v.startswith(name):
-                name_aliases.add(k)
-                name_aliases.add(v)
+        # The below aliasing is resulting in several false positives for npm
+        if pkg_type not in ("npm",):
+            for k, v in config.package_alias.items():
+                if name.startswith(k) or k.startswith(name) or v.startswith(name):
+                    name_aliases.add(k)
+                    name_aliases.add(v)
     if pkg_type in config.OS_PKG_TYPES:
         if "lib" in name:
             name_aliases.add(name.replace("lib", ""))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "owasp-depscan"
-version = "5.0.3"
+version = "5.0.4"
 description = "Fully open-source security audit for project dependencies based on known vulnerabilities and advisories."
 authors = [
     {name = "Team AppThreat", email = "cloud@appthreat.com"},


### PR DESCRIPTION
If an npm package has no vendor and is 2 or 3 letters, such as co, it is getting aliased to connect and so on, resulting in false positives.

```
PYTHONPATH=. python depscan/cli.py --purl  "pkg:npm/co@4.6.0" --reports-dir /tmp/reports
```

cc: @heubeck 