### PR TITLE
Declare variables required for report

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{yml,yaml}]
+indent_size = 2

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,49 @@
+name: Bug Report
+description: File a bug report
+title: "Bug: "
+labels: ["bug"]
+assignees:
+  - cerrussell
+  - prabhu
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ### Thank you for taking your time to fill out this bug report!
+        Please also search the [issues](https://github.com/owasp-dep-scan/dep-scan/issues) first before submitting a new one.
+
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected Behavior
+      description: |
+        Tell us what should happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual-behavior
+    attributes:
+      label: Actual Behavior
+      description: |
+        Tell us what happens instead of the expected behavior.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps to Reproduce
+      description: |
+        Please provide a step by step instruction to reproduce this bug if applicable.
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-info
+    attributes:
+      label: Additional Information
+      description: |
+        Include here any additional information (versions of depscan/ python used, operating system), which you think are relevant to this bug.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+---
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/false_positive.yaml
+++ b/.github/ISSUE_TEMPLATE/false_positive.yaml
@@ -1,0 +1,30 @@
+name: False-Positive Finding
+description: Report a false-positive vulnerability matching
+title: "False-Positive: "
+labels: ["false-positive"]
+assignees:
+  - cerrussell
+  - prabhu
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ### Thank you for reporting a false-positive finding.
+
+  - type: textarea
+    id: false-positive-purl
+    attributes:
+      label: PURL of wrongly matched component
+      description: |
+        Please insert the purl of the component, that was reported for CVEs for no reason.
+    validations:
+      required: true
+
+  - type: textarea
+    id: depscan-output
+    attributes:
+      label: Depscan findings
+      description: |
+        Please insert the output of `depscan --no-banner --sync --purl "purl-of-the-wrong-positive"` here.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,0 +1,31 @@
+name: Feature Request
+description: Request a new feature or change
+title: "Feature: "
+labels: ["enhancement"]
+assignees:
+  - cerrussell
+  - prabhu
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ### Thank you for thinking about, how to evolve depscan.
+        Please also search the [issues](https://github.com/owasp-dep-scan/dep-scan/issues) first before submitting a new one.
+
+  - type: textarea
+    id: request-description
+    attributes:
+      label: Request Description
+      description: |
+        Tell us what should be improved/added/changed/removed and why you think it's necessary.
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional-info
+    attributes:
+      label: Additional Information
+      description: |
+        Include here any additional information, which you think are relevant to this request.
+    validations:
+      required: false

--- a/depscan/cli.py
+++ b/depscan/cli.py
@@ -795,6 +795,8 @@ def main():
     and generates reports based on the results.
     """
     args = build_args()
+    # declare variables that get initialized only conditionally
+    summary, vdr_file, bom_file, pkg_list = None, None, None, None
     # Should we turn on the debug mode
     if args.enable_debug:
         os.environ["AT_DEBUG_MODE"] = "debug"
@@ -869,7 +871,6 @@ def main():
                 expand=False,
             )
         )
-    summary, vdr_file, bom_file  = None, None, None
     for project_type in project_types_list:
         results = []
         report_file = areport_file.replace(".json", f"-{project_type}.json")

--- a/depscan/cli.py
+++ b/depscan/cli.py
@@ -869,6 +869,7 @@ def main():
                 expand=False,
             )
         )
+    summary, vdr_file, bom_file  = None, None, None
     for project_type in project_types_list:
         results = []
         report_file = areport_file.replace(".json", f"-{project_type}.json")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "owasp-depscan"
-version = "5.1.0"
+version = "5.1.1"
 description = "Fully open-source security audit for project dependencies based on known vulnerabilities and advisories."
 authors = [
     {name = "Team AppThreat", email = "cloud@appthreat.com"},


### PR DESCRIPTION
Sometimes there are
```
Traceback (most recent call last):
  File "/usr/local/bin/depscan", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.9/site-packages/depscan/cli.py", line 1118, in main
    vdr_file=vdr_file,
UnboundLocalError: local variable 'vdr_file' referenced before assignment
```
errors on depscan executions, thus declaring all variables used for the
reporting that are initialized only conditionally upfront.
