### PR TITLE
Fix undeclared vars for custom report creation.

### DIFF
--- a/depscan/cli.py
+++ b/depscan/cli.py
@@ -727,7 +727,7 @@ def main():
     """
     args = build_args()
     # declare variables that get initialized only conditionally
-    summary, vdr_file, bom_file, pkg_list = None, None, None, None
+    summary, vdr_file, bom_file, pkg_list, pkg_vulnerabilities, pkg_group_rows = None, None, None, None, None, None
     # Should we turn on the debug mode
     if args.enable_debug:
         os.environ["AT_DEBUG_MODE"] = "debug"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "owasp-depscan"
-version = "5.1.6"
+version = "5.1.7"
 description = "Fully open-source security audit for project dependencies based on known vulnerabilities and advisories."
 authors = [
     {name = "Team AppThreat", email = "cloud@appthreat.com"},


### PR DESCRIPTION
Executing `depscan --report-template depscan.j2 --bom empty.json` with
`empty.json` being only `{}`, depscan fails with

```
Traceback (most recent call last):
  File "/home/heubeck/.local/bin/depscan", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/heubeck/.local/lib/python3.12/site-packages/depscan/cli.py", line 1041, in main                                                                                          pkg_vulnerabilities=pkg_vulnerabilities,
                        ^^^^^^^^^^^^^^^^^^^
UnboundLocalError: cannot access local variable 'pkg_vulnerabilities' where it is not associated with a value
```

Added the with 5.1.6 newly introduced vars to the initialization similar
to the other variables provided to the jinja engine.

