### PR TITLE
Expand the scope of npm alias to search for vendor with the name npm

### DIFF
--- a/depscan/lib/normalize.py
+++ b/depscan/lib/normalize.py
@@ -54,9 +54,17 @@ def create_pkg_variations(pkg_dict):
             if purl_obj:
                 pkg_type = purl_obj.get("type")
                 qualifiers = purl_obj.get("qualifiers", {})
-                # npm is resulting in false positives
-                # Let's disable aliasing for now. See #194, #195, #196
                 if pkg_type in ("npm",):
+                    # vendorless package could have npm as the vendor name from sources such as osv
+                    # So we need 1 more alias
+                    if not purl_obj.get("namespace") and not vendor:
+                        pkg_list.append(
+                            {
+                                "vendor": "npm",
+                                "name": pkg_dict.get("name"),
+                                "version": pkg_dict.get("version"),
+                            }
+                        )
                     return pkg_list
                 if qualifiers and qualifiers.get("distro_name"):
                     os_distro_name = qualifiers.get("distro_name")
@@ -192,9 +200,10 @@ def create_pkg_variations(pkg_dict):
                 )
     elif len(name_aliases) > 1:
         for nvar in list(name_aliases):
+            # vendor could be none which is fine
             pkg_list.append(
                 {
-                    "vendor": pkg_dict.get("vendor"), # Could be none which is fine
+                    "vendor": pkg_dict.get("vendor"),
                     "name": nvar,
                     "version": pkg_dict["version"],
                 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "owasp-depscan"
-version = "5.2.6"
+version = "5.2.7"
 description = "Fully open-source security audit for project dependencies based on known vulnerabilities and advisories."
 authors = [
     {name = "Team AppThreat", email = "cloud@appthreat.com"},
 ]
 dependencies = [
-    "appthreat-vulnerability-db==5.6.1",
+    "appthreat-vulnerability-db==5.6.2",
     "defusedxml",
     "oras==0.1.26",
     "PyYAML",


### PR DESCRIPTION
For the attached sbom, we get results for all versions of axios from both npm and osv. Previously, osv results were getting lost due to the use of `npm` as the vendor name.

```
Dependency Scan Results (JS)
╔═══════════════════════════════════════════════════════════════════╤═══════════════════════════════════╤═══════════════════╤══════════════╤═════════╗
║ Dependency Tree                                                   │ Insights                          │ Fix Version       │ Severity     │   Score ║
╟───────────────────────────────────────────────────────────────────┼───────────────────────────────────┼───────────────────┼──────────────┼─────────╢
║ snowflake-sdk@1.9.0                                               │ 📓 Indirect dependency            │ 1.6.0             │ MEDIUM       │     6.5 ║
║ └── axios@1.5.1 ⬅ CVE-2023-45857                                  │                                   │                   │              │         ║
╟───────────────────────────────────────────────────────────────────┼───────────────────────────────────┼───────────────────┼──────────────┼─────────╢
║ axios@0.21.4                                                      │ 📓 Indirect dependency            │ 1.15.4            │ MEDIUM       │     6.1 ║
║ └── follow-redirects@1.15.2 ⬅ CVE-2023-26159                      │                                   │                   │              │         ║
╟───────────────────────────────────────────────────────────────────┼───────────────────────────────────┼───────────────────┼──────────────┼─────────╢
║ webhook@6.1.0                                                     │ 📓 Indirect dependency            │ 1.6.0             │ MEDIUM       │     6.5 ║
║ └── axios@0.21.4 ⬅ CVE-2023-45857                                 │                                   │                   │              │         ║
╟───────────────────────────────────────────────────────────────────┼───────────────────────────────────┼───────────────────┼──────────────┼─────────╢
║ issue-dup-versions@1.0.0                                          │ 📓 Indirect dependency            │ 1.6.0             │ MEDIUM       │     6.5 ║
║ └── axios@0.27.2 ⬅ CVE-2023-45857                                 │                                   │                   │              │         ║
╟───────────────────────────────────────────────────────────────────┼───────────────────────────────────┼───────────────────┼──────────────┼─────────╢
║ parse-bmfont-xml@1.1.4                                            │ 📓 Indirect dependency            │ 0.5.0             │ MEDIUM       │     5.3 ║
║ └── xml2js@0.4.23 ⬅ CVE-2023-0842                                 │                                   │                   │              │         ║
╚═══════════════════════════════════════════════════════════════════╧═══════════════════════════════════╧═══════════════════╧══════════════╧═════════╝
╭────────────── Recommendation ───────────────╮
│ ✅ No package requires immediate attention. │
╰─────────────────────────────────────────────╯
```

[sbom-js.json.txt](https://github.com/owasp-dep-scan/dep-scan/files/14233351/sbom-js.json.txt)

@heubeck, could you kindly test if this results in false positives for you since this is a fix requested by another enterprise client?