### PR TITLE
Corrects scenario where no src_dir is set -5.x

### DIFF
--- a/depscan/cli.py
+++ b/depscan/cli.py
@@ -353,9 +353,9 @@ def scan(db, project_type, pkg_list, suggest_mode):
                         purl_obj = parse_purl(k)
                         vendor = purl_obj.get("namespace")
                         if not vendor:
-                            vendor = purl_obj.get("type")
-                        name = purl_obj.get("name")
-                        version = purl_obj.get("version")
+                            vendor = purl_obj.get("type") or ""
+                        name = purl_obj.get("name") or ""
+                        version = purl_obj.get("version") or ""
                         sug_pkg_list.append(
                             {
                                 "vendor": vendor,
@@ -774,6 +774,8 @@ def main():
         # Try to infer from the bom file
         elif args.bom and os.path.exists(args.bom):
             src_dir = os.path.dirname(os.path.realpath(args.bom))
+        else:
+            src_dir = os.getcwd()
     reports_dir = args.reports_dir
     if args.csaf:
         toml_file_path = os.getenv(
@@ -805,7 +807,7 @@ def main():
         purl_obj["vendor"] = purl_obj.get("namespace")
         project_types_list = [purl_obj.get("type")]
         pkg_list = [purl_obj]
-    elif args.bom and not args.project_type:
+    elif args.bom:
         project_types_list = ["bom"]
     elif not args.non_universal_scan:
         project_types_list = [UNIVERSAL_SCAN_TYPE]

--- a/depscan/lib/normalize.py
+++ b/depscan/lib/normalize.py
@@ -40,9 +40,9 @@ def create_pkg_variations(pkg_dict):
     pkg_list = [{**pkg_dict}]
     vendor_aliases = set()
     name_aliases = set()
-    vendor = pkg_dict.get("vendor")
-    name = pkg_dict.get("name")
-    purl = pkg_dict.get("purl", "")
+    vendor = pkg_dict.get("vendor") or ""
+    name = pkg_dict.get("name") or ""
+    purl = pkg_dict.get("purl") or ""
     pkg_type = ""
     name_aliases.add(name)
     name_aliases.add(name.lower())


### PR DESCRIPTION
Trying to get the src_dir from the bom path is good, but we need to still set src_dir to the current working directory if depscan hasn't been run using the --bom argument (or when the bom does not actually exist). Otherwise, we will run into problems as we later assume src_dir has been set and try to use it, which will result in an exception.

```python
    if not src_dir or src_dir == ".":
        if src_dir == "." or args.search_purl:
            src_dir = os.getcwd()
        # Try to infer from the bom file
        elif args.bom and os.path.exists(args.bom):
            src_dir = os.path.dirname(os.path.realpath(args.bom))
``` 
This PR corrects the problem.