### PR TITLE
Support for gem with platform name in the version number

### DIFF
--- a/depscan/lib/config.py
+++ b/depscan/lib/config.py
@@ -549,3 +549,15 @@ OS_PKG_UNINSTALLABLE = (
 )
 
 OS_PKG_IGNORABLE = ("linux", "systemd", "ncurses", "kernel")
+
+RUBY_PLATFORM_MARKERS = [
+  "-x86_64",
+  "-x86",
+  "-x64",
+  "-aarch",
+  "-arm",
+  "-ruby",
+  "-universal",
+  "-java",
+  "-truffle"
+]

--- a/depscan/lib/normalize.py
+++ b/depscan/lib/normalize.py
@@ -66,6 +66,19 @@ def create_pkg_variations(pkg_dict):
                             }
                         )
                     return pkg_list
+                # For Rubygems, version string could include the plaform.
+                # So we create an alias without the platform to improve the results
+                if pkg_type in ("gem",):
+                    for plaform_marker in config.RUBY_PLATFORM_MARKERS:
+                        if pkg_dict.get("version") and plaform_marker in pkg_dict["version"]:
+                            pkg_list.append(
+                                {
+                                    "vendor": vendor,
+                                    "name": pkg_dict.get("name"),
+                                    "version": pkg_dict["version"].split(plaform_marker)[0],
+                                }
+                            )
+                            break
                 if qualifiers and qualifiers.get("distro_name"):
                     os_distro_name = qualifiers.get("distro_name")
                     name_aliases.add(f"""{os_distro_name}/{name}""")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "owasp-depscan"
-version = "5.2.8"
+version = "5.2.9"
 description = "Fully open-source security audit for project dependencies based on known vulnerabilities and advisories."
 authors = [
     {name = "Team AppThreat", email = "cloud@appthreat.com"},


### PR DESCRIPTION
Example:

```
"group": "",
"name": "bcrypt_pbkdf",
"version": "1.1.0-x64-mingw32",
```

The version number would be aliased to `1.1.0`. Requires cdxgen 10.1.2.