### PR TITLE
Added alias for azure. Thanks NVD

### DIFF
--- a/depscan/lib/config.py
+++ b/depscan/lib/config.py
@@ -85,6 +85,7 @@ vendor_alias = {
     "io.springfox": "smartbear",
     "log4net": "apache",
     "github": "github actions",
+    "microsoft": "azure"
 }
 
 # Package aliases

--- a/depscan/lib/normalize.py
+++ b/depscan/lib/normalize.py
@@ -140,6 +140,8 @@ def create_pkg_variations(pkg_dict):
         if not name.startswith("python-"):
             name_aliases.add("python-" + name)
             name_aliases.add("python-" + name + "_project")
+            # Eg: numpy:numpy
+            vendor_aliases.add(name)
             # Issue #262
             # Eg: cpe:2.3:a:microsoft:azure_storage_blobs:*:*:*:*:*:python:*:*
             # pypi name is pkg:pypi/azure-storage-blob@12.8.0
@@ -204,10 +206,12 @@ def create_pkg_variations(pkg_dict):
         if "-bin" not in name:
             name_aliases.add(name + "-bin")
     else:
-        # Filter vendor aliases that are also name aliases
-        vendor_aliases = [
-            x for x in vendor_aliases if x not in name_aliases or x == vendor
-        ]
+        # Filter vendor aliases that are also name aliases for non pypi packages
+        # This is needed for numpy which has the vendor name numpy
+        if not purl.startswith("pkg:pypi"):
+            vendor_aliases = [
+                x for x in vendor_aliases if x not in name_aliases or x == vendor
+            ]
     if len(vendor_aliases) > 1:
         for vvar in list(vendor_aliases):
             for nvar in list(name_aliases):

--- a/depscan/lib/normalize.py
+++ b/depscan/lib/normalize.py
@@ -130,6 +130,8 @@ def create_pkg_variations(pkg_dict):
                 vendor_aliases.add(v)
             elif name == k:
                 vendor_aliases.add(v)
+            elif name.startswith(v):
+                vendor_aliases.add(k)
     # This will add false positives to ubuntu
     if "/" in name and os_distro and "ubuntu" not in os_distro:
         name_aliases.add(name.split("/")[-1])
@@ -138,6 +140,11 @@ def create_pkg_variations(pkg_dict):
         if not name.startswith("python-"):
             name_aliases.add("python-" + name)
             name_aliases.add("python-" + name + "_project")
+            # Issue #262
+            # Eg: cpe:2.3:a:microsoft:azure_storage_blobs:*:*:*:*:*:python:*:*
+            # pypi name is pkg:pypi/azure-storage-blob@12.8.0
+            if not name.endswith("s"):
+                name_aliases.add(name.replace("-", "_") + "s")
         vendor_aliases.add("pip")
         vendor_aliases.add("pypi")
         vendor_aliases.add("python")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "owasp-depscan"
-version = "5.2.10"
+version = "5.2.11"
 description = "Fully open-source security audit for project dependencies based on known vulnerabilities and advisories."
 authors = [
     {name = "Team AppThreat", email = "cloud@appthreat.com"},


### PR DESCRIPTION
Fixes #262 

```
python depscan/cli.py --purl "pkg:pypi/azure-storage-blob@12.8.0" --reports-dir /tmp/reports
```

```
Dependency Scan Results (PYPI)
╔════════════════════════════════════════════════════════════════════════════╤═════════════════╤═══════════════════════╤═════════════════╤═══════════╗
║ CVE                                                                        │ Insights        │ Fix Version           │ Severity        │     Score ║
╟────────────────────────────────────────────────────────────────────────────┼─────────────────┼───────────────────────┼─────────────────┼───────────╢
║ azure-storage-blob@12.8.0 ⬅ CVE-2022-30187                                 │                 │ 12.13.0               │ MEDIUM          │       4.7 ║
╚════════════════════════════════════════════════════════════════════════════╧═════════════════╧═══════════════════════╧═════════════════╧═══════════╝
```

```
python depscan/cli.py --purl "pkg:pypi/wheel@0.30.0" --reports-dir /tmp/reports
```

```
Dependency Scan Results (PYPI)
╔═══════════════════════════════════════════════════════════════╤═════════════════════╤══════════════════════════╤════════════════════╤══════════════╗
║ CVE                                                           │ Insights            │ Fix Version              │ Severity           │        Score ║
╟───────────────────────────────────────────────────────────────┼─────────────────────┼──────────────────────────┼────────────────────┼──────────────╢
║ wheel@0.30.0 ⬅ CVE-2022-40898                                 │                     │ 0.38.1                   │ HIGH               │          7.5 ║
╚═══════════════════════════════════════════════════════════════╧═════════════════════╧══════════════════════════╧════════════════════╧══════════════╝
```

```
python depscan/cli.py --purl "pkg:pypi/numpy@1.21.3" --reports-dir /tmp/reports
```

```
Dependency Scan Results (PYPI)
╔═══════════════════════════════════════════════════════╤═════════════════════════════════════╤═══════════════════════╤══════════════════╤═══════════╗
║ CVE                                                   │ Insights                            │ Fix Version           │ Severity         │     Score ║
╟───────────────────────────────────────────────────────┼─────────────────────────────────────┼───────────────────────┼──────────────────┼───────────╢
║ numpy@1.21.3 ⬅ CVE-2021-34141                         │ 🧾 Vendor Confirmed                 │ 1.22                  │ MEDIUM           │       5.3 ║
╚═══════════════════════════════════════════════════════╧═════════════════════════════════════╧═══════════════════════╧══════════════════╧═══════════╝
```
