### PR TITLE
fixing keyerror in version and purl

### DIFF
--- a/depscan/lib/analysis.py
+++ b/depscan/lib/analysis.py
@@ -1495,7 +1495,7 @@ def find_purl_usages(bom_file, src_dir, reachables_slices_file):
             data = json.load(f)
 
         for c in data["components"]:
-            purl = c["purl"]
+            purl = c.get("purl", "")
             if c.get("evidence") and c["evidence"].get("occurrences"):
                 direct_purls[purl] += len(c["evidence"].get("occurrences"))
     return dict(direct_purls), dict(reached_purls)

--- a/depscan/lib/normalize.py
+++ b/depscan/lib/normalize.py
@@ -219,7 +219,7 @@ def create_pkg_variations(pkg_dict):
                     {
                         "vendor": vvar,
                         "name": nvar,
-                        "version": pkg_dict["version"],
+                        "version": pkg_dict.get("version", ""),
                     }
                 )
     elif len(name_aliases) > 1:
@@ -229,7 +229,7 @@ def create_pkg_variations(pkg_dict):
                 {
                     "vendor": pkg_dict.get("vendor"),
                     "name": nvar,
-                    "version": pkg_dict["version"],
+                    "version": pkg_dict.get("version", ""),
                 }
             )
     return pkg_list


### PR DESCRIPTION
when scan on sboms from trivy and syft sometimes happens keyerror. This PR fixes it.