### PR TITLE
Add compatibility for future oras releases

### DIFF
--- a/depscan/lib/orasclient.py
+++ b/depscan/lib/orasclient.py
@@ -22,7 +22,7 @@ class VdbDistributionRegistry(oras.provider.Registry):
     jsonschema.exceptions.ValidationError: Additional properties are not allowed ('artifactType' was unexpected)
     """
 
-    def get_manifest(self, container, allowed_media_type=None):
+    def get_manifest(self, container, allowed_media_type=None, refresh_headers=True):
         """
         Retrieve a manifest for a package.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 dependencies = [
     "appthreat-vulnerability-db>=5.6.2",
     "defusedxml",
-    "oras==0.1.26",
+    "oras~=0.1.26",
     "PyYAML",
     "rich",
     "quart",


### PR DESCRIPTION
`get_manifest` seem to have an extra parameter in oras-py. Adding this should not break v0.1.26, but should allow flexibility for package manager repositories that only contains future versions.