### PR TITLE
Add SECURITY.md with vulnerability reporting and disclosure policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,41 @@
+# Security Policy
+
+## Supported Versions
+
+The OWASP dep-scan project is committed to providing security updates and patches for the latest released version. We recommend always using the most recent version to ensure you have the latest security fixes.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| latest  | :white_check_mark: |
+
+## Reporting a Vulnerability
+
+We take the security of OWASP dep-scan seriously. If you discover a potential security vulnerability, please follow these steps to report it:
+
+1. Email the project maintainer at prabhu@appthreat.com with a detailed description of the vulnerability.
+2. Do not disclose the vulnerability publicly until it has been addressed by the project maintainer.
+3. You will receive an acknowledgment of your report within 48 hours, and the maintainer will work with you to verify and resolve the issue.
+4. Once the vulnerability has been fixed, we will publicly acknowledge your responsible disclosure (unless you prefer to remain anonymous).
+
+## Vulnerability Management
+
+Here's an overview of our vulnerability management process:
+
+1. Reported vulnerabilities are assigned to the primary maintainer within 48 hours.
+2. The vulnerability is verified and a fix is developed in a private branch.
+3. A new version of OWASP dep-scan is released with the vulnerability fix.
+4. The vulnerability is publicly disclosed with due credit to the reporter.
+
+## Bug Bounty
+
+Currently, OWASP dep-scan does not have a formal bug bounty program. However, we greatly appreciate any vulnerability reports from the community and will publicly acknowledge responsible disclosures.
+
+## Secure Development Practices
+
+The OWASP dep-scan project follows secure coding practices, including:
+
+- Regular code reviews and security audits
+- Use of automated static analysis tools
+- Continuous integration and delivery with security checks
+- Dependabot for automated dependency updates
+- Least privilege access controls for project maintainers


### PR DESCRIPTION
This introduces a SECURITY.md file to the project, outlining the OWASP dep-scan security policy. The file covers the following key points:
- Supported versions and commitment to providing security updates
- Instructions for reporting vulnerabilities to the project maintainer
- Overview of the vulnerability management process
- Statement on the current absence of a bug bounty program
- Secure development practices followed by the project
- Placeholder for acknowledging responsible vulnerability disclosures

The main contact for reporting vulnerabilities is listed as prabhu@appthreat.com.

This policy demonstrates the project's commitment to maintaining a secure codebase and handling vulnerability reports responsibly. It provides guidance to security researchers and users on how to engage with the project for security-related concerns.

Please feel free to modify it in any way that you believe is suitable.