### PR TITLE
Consider deprecated packages as more risky. Ported to v6

### DIFF
--- a/depscan/lib/analysis.py
+++ b/depscan/lib/analysis.py
@@ -1110,6 +1110,7 @@ def analyse_pkg_risks(
         if risk_metrics.get("risk_score") and (
             risk_metrics.get("risk_score") > config.pkg_max_risk_score
             or risk_metrics.get("pkg_private_on_public_registry_risk")
+            or risk_metrics.get("pkg_deprecated_risk")
         ):
             risk_score = f"""{round(risk_metrics.get("risk_score"), 2)}"""
             data = [

--- a/depscan/lib/pkg_query.py
+++ b/depscan/lib/pkg_query.py
@@ -319,6 +319,11 @@ def pypi_pkg_risk(pkg_metadata, is_private_pkg, scope):
     versions_dict = pkg_metadata.get("releases", {})
     versions = [ver[0] for k, ver in versions_dict.items() if ver]
     is_deprecated = info.get("yanked") and info.get("yanked_reason")
+    # Some packages like pypi:azure only mention deprecated in the description
+    # without yanking the package
+    pkg_description = info.get("description", "").lower()
+    if not is_deprecated and ("is deprecated" in pkg_description or "no longer maintained" in pkg_description):
+        is_deprecated = True
     latest_deprecated = False
     first_version = None
     latest_version = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
     {name = "Team AppThreat", email = "cloud@appthreat.com"},
 ]
 dependencies = [
-    "appthreat-vulnerability-db>=5.6.6",
+    "appthreat-vulnerability-db==5.6.6",
     "defusedxml",
     "oras~=0.1.26",
     "PyYAML",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
     {name = "Team AppThreat", email = "cloud@appthreat.com"},
 ]
 dependencies = [
-    "appthreat-vulnerability-db>=5.6.2",
+    "appthreat-vulnerability-db>=5.6.6",
     "defusedxml",
     "oras~=0.1.26",
     "PyYAML",


### PR DESCRIPTION
Couple of examples

![risk-audit](https://github.com/owasp-dep-scan/dep-scan/assets/7842/81602165-20e0-4ec8-b08a-5ad35c2c6999)
