### PR TITLE
Added generic cdxgen_args that can be passed as an environment variable or argument to depscan itself.

### DIFF
--- a/depscan/cli.py
+++ b/depscan/cli.py
@@ -131,6 +131,12 @@ def build_args():
         help="Perform package risk audit (slow operation). Npm only.",
     )
     parser.add_argument(
+        "--cdxgen-args",
+        default=os.getenv("CDXGEN_ARGS"),
+        dest="cdxgen_args",
+        help="Additional arguments to pass to cdxgen"
+    )
+    parser.add_argument(
         "--private-ns",
         dest="private_ns",
         default=os.getenv("PKG_PRIVATE_NAMESPACE"),
@@ -897,7 +903,7 @@ def main():
                 bom_file,
                 src_dir,
                 args.deep_scan,
-                {"cdxgen_server": args.cdxgen_server, "profile": args.profile},
+                {"cdxgen_server": args.cdxgen_server, "profile": args.profile, "cdxgen_args": args.cdxgen_args},
             )
         if not creation_status:
             LOG.debug("Bom file %s was not created successfully", bom_file)

--- a/depscan/lib/bom.py
+++ b/depscan/lib/bom.py
@@ -1,5 +1,6 @@
 import json
 import os
+import shlex
 import shutil
 import subprocess
 import sys
@@ -390,6 +391,8 @@ def create_bom(project_type, bom_file, src_dir=".", deep=False, options={}):
         args.append(options.get("profile"))
         if options.get("profile") != "generic":
             LOG.debug("BOM Profile: %s", options.get("profile"))
+    if options.get("cdxgen_args"):
+        args += shlex.split(options.get("cdxgen_args"))
     # Bug #233 - Source directory could be None when working with url
     if src_dir:
         args.append(src_dir)


### PR DESCRIPTION
Creating a new PR for this one with signed commits.

It can be populated in two ways:

With the `--cdxgen-args` argument:
<img width="918" alt="image" src="https://github.com/owasp-dep-scan/dep-scan/assets/10911975/842905e8-783b-4d17-91fe-c37b17545682">

or

 With the `CDXGEN_ARGS` environment variable:
<img width="926" alt="image" src="https://github.com/owasp-dep-scan/dep-scan/assets/10911975/15a3c92b-8559-4a9a-8364-494cd904ba86">
