### PR TITLE
depscan was reporting redis:redis for pypi:redis

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,7 +74,7 @@ RUN set -e; \
     && sdk offline enable \
     && mv /root/.sdkman/candidates/* /opt/ \
     && rm -rf /root/.sdkman \
-    && npm install -g @cyclonedx/cdxgen@10.4.1 \
+    && npm install -g @cyclonedx/cdxgen@10.5.0 \
     && cdxgen --version \
     && curl -LO "https://dl.google.com/go/go${GO_VERSION}.linux-${GOBIN_VERSION}.tar.gz" \
     && tar -C /usr/local -xzf go${GO_VERSION}.linux-${GOBIN_VERSION}.tar.gz \

--- a/depscan/lib/config.py
+++ b/depscan/lib/config.py
@@ -156,7 +156,9 @@ package_alias = {
     "Microsoft.IdentityModel.Clients.ActiveDirectory": "active_directory_authentication_library",
     "starkbank_ecdsa": "ecdsa-elixir",
     "php-pear": "pear-core-minimal",
-    "Selenium.WebDriver": "selenium"
+    "Selenium.WebDriver": "selenium",
+    "selenium": "selenium",
+    "numpy": "numpy"
 }
 
 # Default ignore list

--- a/depscan/lib/normalize.py
+++ b/depscan/lib/normalize.py
@@ -207,12 +207,12 @@ def create_pkg_variations(pkg_dict):
         if "-bin" not in name:
             name_aliases.add(name + "-bin")
     else:
-        # Filter vendor aliases that are also name aliases for non pypi packages
+        # Filter vendor aliases that are also name aliases
         # This is needed for numpy which has the vendor name numpy
         # Also needed for nuget. Eg: selenium:selenium
-        if not purl.startswith("pkg:pypi") and not purl.startswith("pkg:nuget"):
+        if not purl.startswith("pkg:nuget"):
             vendor_aliases = [
-                x for x in vendor_aliases if x not in name_aliases or x == vendor
+                x for x in vendor_aliases if x not in name_aliases or x == vendor or config.package_alias.get(x) is not None
             ]
     if len(vendor_aliases) > 1:
         for vvar in list(vendor_aliases):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "owasp-depscan"
-version = "5.3.3"
+version = "5.3.4"
 description = "Fully open-source security audit for project dependencies based on known vulnerabilities and advisories."
 authors = [
     {name = "Team AppThreat", email = "cloud@appthreat.com"},


### PR DESCRIPTION
numpy:numpy must be reported for pypi:numpy. However, redis:redis must not be reported for pypi:redis even though it has CPE similar to numpy.

This is fixed by adding numpy to package_alias and filtering vendor == name for non-nuget ecosystems.