### PR TITLE
[Fix] Dockerfile - almalinux build is broken and make python version an argument

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM almalinux:9.3-minimal
+FROM almalinux:9.4-minimal
 
 LABEL maintainer="AppThreat" \
       org.opencontainers.image.authors="Team AppThreat <cloud@appthreat.com>" \
@@ -17,6 +17,8 @@ ARG SBT_VERSION=1.9.8
 ARG MAVEN_VERSION=3.9.6
 ARG GRADLE_VERSION=8.5
 ARG NYDUS_VERSION=2.2.4
+ARG PYTHON_VERSION=3.12
+
 ENV GOPATH=/opt/app-root/go \
     GO_VERSION=1.21.5 \
     JAVA_VERSION=$JAVA_VERSION \
@@ -52,12 +54,11 @@ RUN set -e; \
         *) echo >&2 "error: unsupported architecture: '$ARCH_NAME'"; exit 1 ;; \
     esac; \
     echo -e "[nodejs]\nname=nodejs\nstream=20\nprofiles=\nstate=enabled\n" > /etc/dnf/modules.d/nodejs.module \
-    && microdnf module enable php ruby -y \
     && microdnf install -y php php-curl php-zip php-bcmath php-json php-pear php-mbstring php-devel make gcc git-core \
-        python3.11 python3.11-devel python3.11-pip ruby ruby-devel \
+        python${PYTHON_VERSION} python${PYTHON_VERSION}-devel python${PYTHON_VERSION}-pip ruby ruby-devel \
         libX11-devel libXext-devel libXrender-devel libjpeg-turbo-devel \
         pcre2 which tar zip unzip sudo nodejs ncurses glibc-common glibc-all-langpacks xorg-x11-fonts-75dpi xorg-x11-fonts-Type1 \
-    && alternatives --install /usr/bin/python3 python /usr/bin/python3.11 1 \
+    && alternatives --install /usr/bin/python3 python /usr/bin/python${PYTHON_VERSION} 1 \
     && python3 --version \
     && node --version \
     && python3 -m pip install --upgrade pip \


### PR DESCRIPTION
Fixes: #304 
docker image size: 2.82 GB (3032606438 bytes)