### PR TITLE
Use the bin block and name suffixes to report possible binary

### DIFF
--- a/depscan/lib/config.py
+++ b/depscan/lib/config.py
@@ -591,3 +591,7 @@ RUBY_PLATFORM_MARKERS = [
     "-java",
     "-truffle",
 ]
+
+# List of suffixes used by npm packages to indicate binary versions.
+# This could be replaced with a better heuristics or lookup database in the future.
+NPM_BINARY_PACKAGES_SUFFIXES = ("-prebuilt", "-binary")

--- a/depscan/lib/pkg_query.py
+++ b/depscan/lib/pkg_query.py
@@ -16,6 +16,8 @@ def maybe_binary_npm_package(name: str) -> bool:
     :param name: Packagename
     :returns: boolean
     """
+    if not name:
+        return False
     for bin_suffix in config.NPM_BINARY_PACKAGES_SUFFIXES:
         if name.endswith(bin_suffix):
             return True


### PR DESCRIPTION
Fixes #317 

```
Risk Audit Summary (npm)
╔════════════════════════════════════════════╤════════════════╤══════════════════════════╤═══════════════════════════════════════════════════════════╗
║ Package                                    │ Used?          │               Risk Score │ Identified Risks                                          ║
╟────────────────────────────────────────────┼────────────────┼──────────────────────────┼───────────────────────────────────────────────────────────╢
║ phantomjs-prebuilt                         │ N/A            │                     0.44 │ ❌ Deprecated                                             ║
║                                            │                │                          │ ❌ Includes binary                                        ║
║                                            │                │                          │ Binary commands:                                          ║
║                                            │                │                          │ phantomjs: ./bin/phantomjs                                ║
║                                            │                │                          │ ⚠ No recent updates                                       ║
╚════════════════════════════════════════════╧════════════════╧══════════════════════════╧═══════════════════════════════════════════════════════════╝
```