### PR TITLE
npm binary research

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,11 @@ dep-scan is ideal for use during continuous integration (CI) and as a local deve
 
 ```bash
 sudo npm install -g @cyclonedx/cdxgen
+# Normal version recommended for most users (MIT)
 pip install owasp-depscan
+
+# For a performant version, that uses valkey cache during risk audit (BSD-3-Clause)
+pip install owasp-depscan[perf]
 ```
 
 This would install two commands called `cdxgen` and `depscan`.

--- a/contrib/npm-binaries/README.md
+++ b/contrib/npm-binaries/README.md
@@ -11,13 +11,13 @@ python -m pip install .
 cd contrib/npm-binaries
 pip install -r requirements.txt
 
-# Signup and get an api key for libraries.io
+# Optional: Signup and get an api key for libraries.io
 export LIBRARIES_API_KEY=key
 
 # Search for packages by keywords
 python collect.py --keywords binary,prebuilt -o report.csv
 
-# top popular packages
+# Top popular packages. Uses npm search
 python collect.py --popular -o report.csv
 ```
 

--- a/contrib/npm-binaries/README.md
+++ b/contrib/npm-binaries/README.md
@@ -1,0 +1,39 @@
+# Introduction
+
+This folder contains a script to collect npm packages with binary risks. libraries.io API is used for the initial search for packages based on popularity or rank. Depscan pkg_query is then used as a library to identify binary risk with the results stored in a CSV file.
+
+## Usage
+
+```
+git clone https://github.com/owasp-dep-scan/dep-scan.git
+cd dep-scan
+python -m pip install .
+cd contrib/npm-binaries
+pip install -r requirements.txt
+
+# Search for packages by keywords
+python collect.py --keywords binary,prebuilt -o report.csv
+
+# top popular packages
+python collect.py --popular -o report.csv
+```
+
+The full list of options is below:
+
+```shell
+python collect.py --help
+usage: collect.py [-h] [--keywords KEYWORDS] [-s {rank,stars,dependents_count,dependent_repos_count,contributions_count}] [-t {npm}] [-o OUTPUT_FILE] [--popular]
+
+Collect npm packages for given search strings.
+
+options:
+  -h, --help            show this help message and exit
+  --keywords KEYWORDS   Comma separated list of keywords to search.
+  -s {rank,stars,dependents_count,dependent_repos_count,contributions_count}, --sort {rank,stars,dependents_count,dependent_repos_count,contributions_count}
+                        Sort options.
+  -t {npm}, --type {npm}
+                        Package type.
+  -o OUTPUT_FILE, --output-file OUTPUT_FILE
+                        Output CSV file.
+  --popular             Top popular packages.
+```

--- a/contrib/npm-binaries/README.md
+++ b/contrib/npm-binaries/README.md
@@ -11,6 +11,9 @@ python -m pip install .
 cd contrib/npm-binaries
 pip install -r requirements.txt
 
+# Signup and get an api key for libraries.io
+export LIBRARIES_API_KEY=key
+
 # Search for packages by keywords
 python collect.py --keywords binary,prebuilt -o report.csv
 

--- a/contrib/npm-binaries/collect.py
+++ b/contrib/npm-binaries/collect.py
@@ -3,7 +3,6 @@ import csv
 import logging
 import os
 
-from pybraries.search import Search
 from rich.progress import Progress
 from semver import Version
 
@@ -31,7 +30,7 @@ def build_args():
     parser.add_argument(
         "--keywords",
         dest="keywords",
-        default="binary,prebuilt,mac,arm,native",
+        default="binary,prebuilt",
         help="Comma separated list of keywords to search.",
     )
     parser.add_argument(
@@ -214,6 +213,7 @@ def main():
     if popular_only:
         analyze_with_npm(keywords, args.pages, args.output_file)
     else:
+        from pybraries.search import Search
         search = Search()
         with Progress(
             console=console,

--- a/contrib/npm-binaries/collect.py
+++ b/contrib/npm-binaries/collect.py
@@ -1,0 +1,201 @@
+import argparse
+import csv
+import logging
+import os
+import sys
+
+from pybraries.search import Search
+from semver import Version
+
+from depscan.lib.logger import console
+from depscan.lib.pkg_query import npm_metadata
+
+for log_name, log_obj in logging.Logger.manager.loggerDict.items():
+    if log_name != __name__:
+        log_obj.disabled = True
+
+PAGES = 21
+PER_PAGE = 100
+
+pkg_versions = {}
+pkg_rank = {}
+pkg_stars = {}
+pkg_dependents_count = {}
+risky_binary_pkgs = {}
+
+
+def build_args():
+    """
+    Constructs command line arguments
+    """
+    parser = argparse.ArgumentParser(
+        description="Collect npm packages for given search strings."
+    )
+    parser.add_argument(
+        "--keywords",
+        dest="keywords",
+        default="binary,prebuilt",
+        help="Comma separated list of keywords to search.",
+    )
+    parser.add_argument(
+        "-s",
+        "--sort",
+        dest="sort_option",
+        default="rank",
+        choices=(
+            "rank",
+            "stars",
+            "dependents_count",
+            "dependent_repos_count",
+            "contributions_count",
+        ),
+        help="Sort options.",
+    )
+    parser.add_argument(
+        "-t",
+        "--type",
+        dest="package_type",
+        default="npm",
+        choices=("npm"),
+        help="Package type.",
+    )
+    parser.add_argument(
+        "-o",
+        "--output-file",
+        dest="output_file",
+        default="report.csv",
+        help="Output CSV file.",
+    )
+    parser.add_argument(
+        "--popular",
+        action="store_true",
+        dest="popular_only",
+        default=False,
+        help="Top popular packages.",
+    )
+    return parser.parse_args()
+
+
+def collect_pkgs(search_result):
+    for res in search_result:
+        pkg_name = res.get("name")
+        versions = [v.get("number") for v in res.get("versions")]
+        try:
+            versions.sort(
+                key=lambda x: Version.parse(x, optional_minor_and_patch=True),
+                reverse=True,
+            )
+        except ValueError:
+            pass
+        pkg_versions[pkg_name] = versions
+        pkg_rank[pkg_name] = res.get("rank")
+        pkg_stars[pkg_name] = res.get("stars")
+        pkg_dependents_count[pkg_name] = res.get("dependents_count")
+
+
+def analyze_pkgs():
+    pkg_list = []
+    for name, versions in pkg_versions.items():
+        version = versions[0]
+        pkg_list.append(
+            {
+                "name": name,
+                "version": version,
+                "purl": f"pkg:npm/{name.replace('@', '%40')}@{version}",
+            }
+        )
+    console.print("About to check", len(pkg_list), "packages for binaries.")
+    metadata_dict = npm_metadata({}, pkg_list, None)
+    for name, value in metadata_dict.items():
+        risk_metrics = value.get("risk_metrics")
+        purl = value.get("purl")
+        if risk_metrics and risk_metrics.get("pkg_includes_binary_risk"):
+            risk_metrics["rank"] = pkg_rank.get(name)
+            risk_metrics["stars"] = pkg_stars.get(name)
+            risk_metrics["dependents_count"] = pkg_dependents_count.get(name)
+            risky_binary_pkgs[purl] = risk_metrics
+
+
+def export_risky_pkgs(output_file):
+    if risky_binary_pkgs:
+        with open(output_file, "w", encoding="utf-8", newline="") as csvfile:
+            rwriter = csv.writer(
+                csvfile, delimiter=',', quotechar='|', quoting=csv.QUOTE_NONE, escapechar='\\'
+            )
+            rwriter.writerow(
+                [
+                    "purl",
+                    "risk_score",
+                    "pkg_includes_binary_risk",
+                    "pkg_includes_binary_info",
+                    "pkg_attested_check",
+                    "pkg_deprecated_risk",
+                    "pkg_version_deprecated_risk",
+                    "pkg_version_missing_risk",
+                    "rank",
+                    "stars",
+                    "dependents_count"
+                ]
+            )
+            for purl, metrics in risky_binary_pkgs.items():
+                rwriter.writerow(
+                    [
+                        purl,
+                        metrics.get("risk_score"),
+                        metrics.get("pkg_includes_binary_risk"),
+                        metrics.get("pkg_includes_binary_info"),
+                        metrics.get("pkg_attested_check"),
+                        metrics.get("pkg_deprecated_risk"),
+                        metrics.get("pkg_version_deprecated_risk"),
+                        metrics.get("pkg_version_missing_risk"),
+                        metrics.get("rank"),
+                        metrics.get("stars"),
+                        metrics.get("dependents_count"),
+                    ]
+                )
+        console.print("Report", output_file, "created successfully")
+    else:
+        console.print(
+            "No risks identified. Try searching with a different keyword or increasing the page count"
+        )
+
+
+def main():
+    if not os.getenv("LIBRARIES_API_KEY"):
+        print(
+            "Set the environment variable LIBRARIES_API_KEY with a valid libraries.io API key"
+        )
+        sys.exit(1)
+    args = build_args()
+    search = Search()
+    if args.popular_only:
+        console.print("Searching for top", PER_PAGE * (PAGES - 1),"popular packages")
+        for page in range(1, PAGES):
+            search_result = search.project_search(
+                keywords="",
+                sort=args.sort_option,
+                platforms=args.package_type,
+                page=page,
+                per_page=PER_PAGE,
+                order="desc"
+            )
+            collect_pkgs(search_result)
+    else:
+        for keyword in args.keywords.split(","):
+            console.print("Search for packages with keyword", keyword)
+            for page in range(1, PAGES):
+                search_result = search.project_search(
+                    keywords=keyword,
+                    sort=args.sort_option,
+                    platforms=args.package_type,
+                    page=page,
+                    per_page=PER_PAGE,
+                    order="desc"
+                )
+                collect_pkgs(search_result)
+    analyze_pkgs()
+    export_risky_pkgs(args.output_file)
+
+
+if __name__ == "__main__":
+    main()

--- a/contrib/npm-binaries/collect.py
+++ b/contrib/npm-binaries/collect.py
@@ -31,7 +31,7 @@ def build_args():
     parser.add_argument(
         "--keywords",
         dest="keywords",
-        default="native,binary,prebuilt",
+        default="binary,prebuilt,mac,arm,native",
         help="Comma separated list of keywords to search.",
     )
     parser.add_argument(

--- a/contrib/npm-binaries/collect.py
+++ b/contrib/npm-binaries/collect.py
@@ -57,7 +57,7 @@ def build_args():
         "--type",
         dest="package_type",
         default="npm",
-        choices=("npm"),
+        choices=("npm",),
         help="Package type.",
     )
     parser.add_argument(
@@ -123,7 +123,11 @@ def export_risky_pkgs(output_file):
     if risky_binary_pkgs:
         with open(output_file, "w", encoding="utf-8", newline="") as csvfile:
             rwriter = csv.writer(
-                csvfile, delimiter=',', quotechar='|', quoting=csv.QUOTE_NONE, escapechar='\\'
+                csvfile,
+                delimiter=",",
+                quotechar="|",
+                quoting=csv.QUOTE_NONE,
+                escapechar="\\",
             )
             rwriter.writerow(
                 [
@@ -137,7 +141,7 @@ def export_risky_pkgs(output_file):
                     "pkg_version_missing_risk",
                     "rank",
                     "stars",
-                    "dependents_count"
+                    "dependents_count",
                 ]
             )
             for purl, metrics in risky_binary_pkgs.items():
@@ -159,7 +163,7 @@ def export_risky_pkgs(output_file):
         console.print("Report", output_file, "created successfully")
     else:
         console.print(
-            "No risks identified. Try searching with a different keyword or increasing the page count"
+            "No risks identified. Try searching with a different keyword."
         )
 
 
@@ -172,7 +176,9 @@ def main():
     args = build_args()
     search = Search()
     if args.popular_only:
-        console.print("Searching for top", PER_PAGE * (PAGES - 1),"popular packages")
+        console.print(
+            "Searching for top", PER_PAGE * (PAGES - 1), "popular packages"
+        )
         for page in range(1, PAGES):
             search_result = search.project_search(
                 keywords="",
@@ -180,7 +186,7 @@ def main():
                 platforms=args.package_type,
                 page=page,
                 per_page=PER_PAGE,
-                order="desc"
+                order="desc",
             )
             collect_pkgs(search_result)
     else:
@@ -193,10 +199,14 @@ def main():
             refresh_per_second=1,
         ) as progress:
             task = progress.add_task(
-                "[green] Searching for packages", total=len(keywords) * PAGES - 1
+                "[green] Searching for packages",
+                total=len(keywords) * PAGES - 1,
             )
             for keyword in keywords:
-                progress.update(task, description=f"Search for packages with keyword `{keyword}`")
+                progress.update(
+                    task,
+                    description=f"Search for packages with keyword `{keyword}`",
+                )
                 for page in range(1, PAGES):
                     search_result = search.project_search(
                         keywords=keyword,
@@ -204,7 +214,7 @@ def main():
                         platforms=args.package_type,
                         page=page,
                         per_page=PER_PAGE,
-                        order="desc"
+                        order="desc",
                     )
                     collect_pkgs(search_result)
                     progress.advance(task)

--- a/contrib/npm-binaries/requirements.txt
+++ b/contrib/npm-binaries/requirements.txt
@@ -1,2 +1,3 @@
 pybraries
 semver
+rich

--- a/contrib/npm-binaries/requirements.txt
+++ b/contrib/npm-binaries/requirements.txt
@@ -1,0 +1,2 @@
+pybraries
+semver

--- a/depscan/lib/config.py
+++ b/depscan/lib/config.py
@@ -594,4 +594,4 @@ RUBY_PLATFORM_MARKERS = [
 
 # List of suffixes used by npm packages to indicate binary versions.
 # This could be replaced with a better heuristics or lookup database in the future.
-NPM_BINARY_PACKAGES_SUFFIXES = ("-prebuilt", "-binary")
+NPM_BINARY_PACKAGES_SUFFIXES = ("-prebuilt",)

--- a/depscan/lib/pkg_query.py
+++ b/depscan/lib/pkg_query.py
@@ -74,11 +74,11 @@ def get_lookup_url(registry_type, pkg):
     return None, None
 
 
-def search_npm(keyword, pages=1, popularity=1, quality=1, size=250):
+def search_npm(keywords, pages=1, popularity=1, size=250):
     pkg_list = []
     for page in range(0, pages):
         from_value = page * 250
-        registry_search_url = f"{config.NPM_SERVER}/-/v1/search?popularity={popularity}&size={size}&from={from_value}&text=keywords:{keyword}&quality={quality}"
+        registry_search_url = f"{config.NPM_SERVER}/-/v1/search?popularity={popularity}&size={size}&from={from_value}&text=keywords:{','.join(keywords)}"
         try:
             r = httpclient.get(
                 url=registry_search_url,
@@ -149,6 +149,7 @@ def metadata_from_registry(
         redirect_stderr=False,
         redirect_stdout=False,
         refresh_per_second=1,
+        disable=len(pkg_list) < 10
     ) as progress:
         task = progress.add_task(
             "[green] Auditing packages", total=len(pkg_list)

--- a/depscan/lib/pkg_query.py
+++ b/depscan/lib/pkg_query.py
@@ -151,6 +151,7 @@ def metadata_from_registry(
                     )
                 metadata_dict[key] = {
                     "scope": scope,
+                    "purl": pkg.get("purl"),
                     "pkg_metadata": json_data,
                     "risk_metrics": risk_metrics,
                     "is_private_pkg": is_private_pkg,

--- a/depscan/lib/pkg_query.py
+++ b/depscan/lib/pkg_query.py
@@ -74,7 +74,7 @@ def get_lookup_url(registry_type, pkg):
     return None, None
 
 
-def search_npm(keywords, pages=1, popularity=1, size=250):
+def search_npm(keywords, pages=1, popularity=1.0, size=250):
     pkg_list = []
     for page in range(0, pages):
         from_value = page * 250

--- a/depscan/lib/pkg_query.py
+++ b/depscan/lib/pkg_query.py
@@ -13,7 +13,7 @@ try:
     import redis
 
     storage = hishel.RedisStorage(
-        ttl=config.get_int_from_env("DEPSCAN_CACHE_TTL", 3600),
+        ttl=config.get_int_from_env("DEPSCAN_CACHE_TTL", 36000),
         client=redis.Redis(
             host=os.getenv("DEPSCAN_CACHE_HOST", "127.0.0.1"),
             port=config.get_int_from_env("DEPSCAN_CACHE_PORT", 6379),
@@ -72,6 +72,25 @@ def get_lookup_url(registry_type, pkg):
     if registry_type == "pypi":
         return key, f"{config.PYPI_SERVER}/{key}/json"
     return None, None
+
+
+def get_npm_download_stats(name, period="last-year"):
+    """
+    Method to download npm stats
+
+    :param name: Package name
+    :param period: Stats period
+    """
+    stats_url = f"https://api.npmjs.org/downloads/point/{period}/{name}"
+    try:
+        r = httpclient.get(
+            url=stats_url,
+            follow_redirects=True,
+            timeout=config.request_timeout_sec,
+        )
+        return r.json()
+    except Exception:
+        return {}
 
 
 def metadata_from_registry(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,11 +47,12 @@ scan = "depscan.cli:main"
 
 [project.optional-dependencies]
 dev = ["black",
-"flake8",
-"pytest",
-"pytest-cov",
-"httpretty"
+    "flake8",
+    "pytest",
+    "pytest-cov",
+    "httpretty"
 ]
+perf = ["hishel[redis]"]
 
 [build-system]
 requires = ["setuptools>=61", "wheel"]


### PR DESCRIPTION
Added a contrib script to search for npm packages using keywords and look for binary risk (based on metadata) in them.

Added hishel package so that risk audit could optionally use valkey cache to reduce http lookups.