### PR TITLE
Fix for generic packages false positives

### DIFF
--- a/depscan/lib/analysis.py
+++ b/depscan/lib/analysis.py
@@ -495,7 +495,6 @@ def prepare_vdr(options: PrepareVdrOptions):
                         has_ubuntu_packages = True
                     if "rhel" in qualifiers.get("distro", ""):
                         has_redhat_packages = True
-
         if ids_seen.get(vid + purl):
             fp_count += 1
             continue

--- a/depscan/lib/analysis.py
+++ b/depscan/lib/analysis.py
@@ -398,8 +398,18 @@ def prepare_vdr(options: PrepareVdrOptions):
                 if not is_os_target_sw(package_issue):
                     fp_count += 1
                     continue
+            # Issue #320 - Malware matches without purl are false positives
+            if vid.startswith("MAL-"):
+                fp_count += 1
+                malicious_count -= 1
+                continue
         else:
             purl_obj = parse_purl(purl)
+            # Issue #320 - Malware matches without purl are false positives
+            if not purl_obj and vid.startswith("MAL-"):
+                fp_count += 1
+                malicious_count -= 1
+                continue
             if purl_obj:
                 version_used = purl_obj.get("version")
                 package_type = purl_obj.get("type")
@@ -485,6 +495,7 @@ def prepare_vdr(options: PrepareVdrOptions):
                         has_ubuntu_packages = True
                     if "rhel" in qualifiers.get("distro", ""):
                         has_redhat_packages = True
+
         if ids_seen.get(vid + purl):
             fp_count += 1
             continue

--- a/depscan/lib/normalize.py
+++ b/depscan/lib/normalize.py
@@ -54,6 +54,9 @@ def create_pkg_variations(pkg_dict):
             if purl_obj:
                 pkg_type = purl_obj.get("type")
                 qualifiers = purl_obj.get("qualifiers", {})
+                # Issue #320. Mandate version number for generic packages to reduce FPs
+                if pkg_type in ("generic",) and not purl_obj.get("version"):
+                    return None
                 if pkg_type in ("npm",):
                     # vendorless package could have npm as the vendor name from sources such as osv
                     # So we need 1 more alias


### PR DESCRIPTION
Restricting generic package searches to only those with version numbers, since the precision of purl from cdxgen is quite low.

Restricting Malware hits to only those with purls.

Fixes #320 