### PR TITLE
Removed project alias for pypi which was resulting in FP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,16 +12,16 @@ LABEL maintainer="AppThreat" \
       org.opencontainers.docker.cmd="docker run --rm -v /tmp:/tmp -p 7070:7070 -v $(pwd):/app:rw -t ghcr.io/owasp-dep-scan/dep-scan --server"
 
 ARG TARGETPLATFORM
-ARG JAVA_VERSION=22.0.1-tem
-ARG SBT_VERSION=1.9.9
-ARG MAVEN_VERSION=3.9.8
-ARG GRADLE_VERSION=8.8
+ARG JAVA_VERSION=22.0.2-tem
+ARG SBT_VERSION=1.10.1
+ARG MAVEN_VERSION=3.9.9
+ARG GRADLE_VERSION=8.10
 ARG NYDUS_VERSION=2.2.5
 ARG CDXGEN_VERSION=10.7.1
 ARG PYTHON_VERSION=3.12
 
 ENV GOPATH=/opt/app-root/go \
-    GO_VERSION=1.22.3 \
+    GO_VERSION=1.22.7 \
     JAVA_VERSION=$JAVA_VERSION \
     SBT_VERSION=$SBT_VERSION \
     MAVEN_VERSION=$MAVEN_VERSION \

--- a/depscan/lib/normalize.py
+++ b/depscan/lib/normalize.py
@@ -155,7 +155,6 @@ def create_pkg_variations(pkg_dict):
         vendor_aliases.add("pypi")
         vendor_aliases.add("python")
         vendor_aliases.add("python-" + name)
-        vendor_aliases.add(name + "project")
     elif purl.startswith("pkg:npm"):
         # pg-promise CVE is filed as pg
         if name.endswith("-promise"):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "owasp-depscan"
-version = "5.4.3"
+version = "5.4.4"
 description = "Fully open-source security audit for project dependencies based on known vulnerabilities and advisories."
 authors = [
     {name = "Team AppThreat", email = "cloud@appthreat.com"},
 ]
 dependencies = [
-    "appthreat-vulnerability-db==5.7.3",
+    "appthreat-vulnerability-db==5.7.5",
     "defusedxml",
     "oras~=0.1.26",
     "PyYAML",


### PR DESCRIPTION
CVEs are no longer reported for `pkg:pypi/pulp@2.9.0` with this fix.