### PR TITLE
Removes aliasing for namespaces that affected maven

### DIFF
--- a/depscan/lib/normalize.py
+++ b/depscan/lib/normalize.py
@@ -101,18 +101,6 @@ def create_pkg_variations(pkg_dict):
         vendor_aliases.add(vendor)
         vendor_aliases.add(vendor.lower())
         vendor_aliases.add(vendor.lstrip("@"))
-        if (
-            vendor.startswith("org.")
-            or vendor.startswith("io.")
-            or vendor.startswith("com.")
-            or vendor.startswith("net.")
-        ):
-            tmpA = vendor.split(".")
-            # Automatically add short vendor forms
-            # Increase to 6 to reduce false positives when the package name is core
-            if len(tmpA) > 1 and len(tmpA[1]) > 6:
-                if tmpA[1] != name:
-                    vendor_aliases.add(tmpA[1])
     # Add some common vendor aliases
     if purl.startswith("pkg:golang") and not name.startswith("go"):
         vendor_aliases.add("go")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "owasp-depscan"
-version = "5.4.5"
+version = "5.4.6"
 description = "Fully open-source security audit for project dependencies based on known vulnerabilities and advisories."
 authors = [
     {name = "Team AppThreat", email = "cloud@appthreat.com"},

--- a/test/test_norm.py
+++ b/test/test_norm.py
@@ -21,7 +21,7 @@ def test_pkg_variations():
     pkg_list = create_pkg_variations(
         {"vendor": "org.eclipse.foo", "name": "bar", "version": "1.0.0"}
     )
-    assert len(pkg_list) > 1
+    assert len(pkg_list) == 1
     pkg_list = create_pkg_variations(
         {
             "vendor": "com.fasterxml.jackson.core",


### PR DESCRIPTION
The below no longer results in false positives.

```
python depscan/cli.py --purl "pkg:maven/org.tukaani/xz@1.9?type=jar" --reports-dir /tmp/reports
```
