### PR TITLE
Cache vdb for consistence in snapshot tests.

### DIFF
--- a/.github/workflows/snapshot_tests.yml
+++ b/.github/workflows/snapshot_tests.yml
@@ -1,0 +1,36 @@
+name: Snapshot Testing
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: "${{ github.workflow }}-${{ github.head_ref || github.run_id }}"
+  cancel-in-progress: true
+
+jobs:
+
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+
+      -  name: Install depscan
+         run: |
+           python -m pip install --upgrade pip
+           python -m venv venv
+           source venv/bin/activate
+           pip install .
+           vdb --download-image
+
+      - name: Cache vdb
+        id: cache-vdb
+        uses: actions/cache@v4
+        with:
+          path: /home/runner/.local/share/vdb
+          key: vdb-snapshot-cache


### PR DESCRIPTION
In order to test what we intend to test, we need to cache the vulnerability database used for the snapshot testing to be implemented in #355.