### PR TITLE
Support for cvss v4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "owasp-depscan"
-version = "5.4.8"
+version = "5.5.0"
 description = "Fully open-source security audit for project dependencies based on known vulnerabilities and advisories."
 authors = [
     {name = "Team AppThreat", email = "cloud@appthreat.com"},
 ]
 dependencies = [
-    "appthreat-vulnerability-db==5.7.8",
+    "appthreat-vulnerability-db==5.8.1",
     "defusedxml",
     "oras~=0.1.26",
     "PyYAML",

--- a/test/test_analysis.py
+++ b/test/test_analysis.py
@@ -708,8 +708,7 @@ def test_cvss_to_vdr_rating():
         "severity": "HIGH",
     }
     # Test missing score and vector string
-    assert cvss_to_vdr_rating(res) == [
-        {'method': 'CVSSv31', 'score': 2.0, 'severity': 'high'}]
+    assert cvss_to_vdr_rating(res) == []
     # Test parsing
     res["cvss_v3"]["vector_string"] = ("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I"
                                        ":N/A:H")
@@ -729,6 +728,24 @@ def test_cvss_to_vdr_rating():
         'severity': 'high',
         'vector': 'CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H'
     }]
+    assert cvss_to_vdr_rating({
+        "cvss_v3": {
+            "vector_string": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:H/A:H"
+        },
+        "cvss4_vector_string": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:N/SC:L/SI:H/SA:H"
+    }) == [{
+        'method': 'CVSSv4',
+        'score': 7.9,
+        'severity': 'high',
+        'vector': 'CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:N/SC:L/SI:H/SA:H'
+    },
+    {
+        'method': 'CVSSv31',
+        'score': 10.0,
+        'severity': 'critical',
+        'vector': 'CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:H/A:H'
+    }
+    ]
 
 
 def test_get_version_range():


### PR DESCRIPTION
Brings cvss v4 support for v5 branch. Also fixes an npm severity inconsistency bug by updating to vdb 5.8.1.

```
python depscan/cli.py --purl "pkg:npm/dompurify@2.3.6" --reports-dir /tmp/reports

██████╗ ███████╗██████╗ ███████╗ ██████╗ █████╗ ███╗   ██╗
██╔══██╗██╔════╝██╔══██╗██╔════╝██╔════╝██╔══██╗████╗  ██║
██║  ██║█████╗  ██████╔╝███████╗██║     ███████║██╔██╗ ██║
██║  ██║██╔══╝  ██╔═══╝ ╚════██║██║     ██╔══██║██║╚██╗██║
██████╔╝███████╗██║     ███████║╚██████╗██║  ██║██║ ╚████║
╚═════╝ ╚══════╝╚═╝     ╚══════╝ ╚═════╝╚═╝  ╚═╝╚═╝  ╚═══╝

INFO [2024-11-10 23:19:47,496] No package risks detected ✅

                                                            Dependency Scan Results (NPM)
╔═══════════════════════════════════════════════════════════════════╤════════════════════╤═════════════════════════╤═══════════════════╤═════════════╗
║ CVE                                                               │ Insights           │ Fix Version             │ Severity          │       Score ║
╟───────────────────────────────────────────────────────────────────┼────────────────────┼─────────────────────────┼───────────────────┼─────────────╢
║ dompurify@2.3.6 ⬅ CVE-2024-45801                                  │                    │ 2.5.4                   │ HIGH              │         7.0 ║
╟───────────────────────────────────────────────────────────────────┼────────────────────┼─────────────────────────┼───────────────────┼─────────────╢
║ dompurify@2.3.6 ⬅ CVE-2024-47875                                  │                    │ 2.5.4                   │ CRITICAL          │        10.0 ║
╟───────────────────────────────────────────────────────────────────┼────────────────────┼─────────────────────────┼───────────────────┼─────────────╢
║ dompurify@2.3.6 ⬅ CVE-2024-48910                                  │                    │ 2.5.4                   │ CRITICAL          │         9.1 ║
╚═══════════════════════════════════════════════════════════════════╧════════════════════╧═════════════════════════╧═══════════════════╧═════════════╝
```