### PR TITLE
Adds components.properties filtering in bom

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ The full list of options is below:
 usage: cli.py [-h] [--no-banner] [] [--csaf] [--sync] [--profile {appsec,research,operational,threat-modeling,license-compliance,generic}] [--no-suggest] [--risk-audit] [--private-ns PRIVATE_NS] [-t PROJECT_TYPE] [--bom BOM]
               [-i SRC_DIR_IMAGE] [-o REPORT_FILE] [--reports-dir REPORTS_DIR] [--report-template REPORT_TEMPLATE] [--report-name REPORT_NAME] [--no-error] [--no-license-scan] [--deep] [--no-universal] [--no-vuln-table]
               [--threatdb-server THREATDB_SERVER] [--threatdb-username THREATDB_USERNAME] [--threatdb-password THREATDB_PASSWORD] [--threatdb-token THREATDB_TOKEN] [--server] [--server-host SERVER_HOST] [--server-port SERVER_PORT]
-              [--cdxgen-server CDXGEN_SERVER] [--debug] [--explain] [--reachables-slices-file REACHABLES_SLICES_FILE] [-v]
+              [--cdxgen-server CDXGEN_SERVER] [--debug] [--explain] [--reachables-slices-file REACHABLES_SLICES_FILE] [--exclude-components-properties LIST_OF_PROPERTY_NAMES] [-v]
 
 Fully open-source security and license audit for application dependencies and container images based on known vulnerabilities and advisories.
 
@@ -160,6 +160,10 @@ options:
   --reachables-slices-file REACHABLES_SLICES_FILE
                         Path for the reachables slices file created by atom.
   --purl SEARCH_PURL    Scan a single package url.
+  --exclude-components-properties LIST_OF_PROPERTY_NAMES
+                        Comma separated list of properties to exclude from the output VDR BOM (sbom-universal.vdr.json) by the property name (i.e. ImportedModules).
+                        The property name is treated as a regular expression in searching.
+                        The properties appear in the JSON structure under components.properties.
   -v, --version         Display the version
 ```
 

--- a/depscan/cli.py
+++ b/depscan/cli.py
@@ -432,7 +432,7 @@ def export_bom(bom_data, pkg_vulnerabilities, vdr_file):
     # Update the tools section
     if isinstance(tools, dict):
         bom_data = summarise_tools(tools, metadata, bom_data)
-    if bom_data["components"]:
+    if bom_data.get("components"):
         bom_data = remove_extra_properties(bom_data)
     bom_data["vulnerabilities"] = pkg_vulnerabilities
     json_dump(vdr_file, bom_data, error_msg=f"Unable to generate VDR file at {vdr_file}", log=LOG)
@@ -449,7 +449,7 @@ def remove_extra_properties(bom_data):
         for key, value in component.items():
             new_component |= {key: value}
 
-        if component["properties"]:      
+        if component.get("properties"):      
             for prop in component["properties"]:
                 new_property = {}
                 keep_property = True

--- a/depscan/cli.py
+++ b/depscan/cli.py
@@ -448,19 +448,21 @@ def remove_extra_properties(bom_data):
 
         for key, value in component.items():
             new_component |= {key: value}
-                
-        for prop in component["properties"]:
-            new_property = {}
-            keep_property = True
-            for key, value in prop.items():
-                if value not in exclude_properties:
-                    new_property |= {key: value}
-                else:
-                    keep_property = False
-            if keep_property == True:
-                new_properties.append(new_property)
 
-        new_component["properties"] = new_properties
+        if component["properties"]:      
+            for prop in component["properties"]:
+                new_property = {}
+                keep_property = True
+                for key, value in prop.items():
+                    if value not in exclude_properties:
+                        new_property |= {key: value}
+                    else:
+                        keep_property = False
+                if keep_property == True:
+                    new_properties.append(new_property)
+
+            new_component["properties"] = new_properties
+            
         new_components.append(new_component)
 
     bom_data["components"] = new_components


### PR DESCRIPTION
Implements https://github.com/owasp-dep-scan/dep-scan/issues/362

Filters the desired components.properties objects by name. This implementation uses an exclude list instead of an allow list. Filtering is applied to the file `sbom-universal.vdr.json`

Attached are before and after bom files to demonstrate filtering in action on an example. In this example, the bom only had the property "ImportedModules"
[after.json](https://github.com/user-attachments/files/17758205/after.json)
[before.json](https://github.com/user-attachments/files/17758206/before.json)
