### PR TITLE
issue-390: Fixed the editURL of docusaurus

### DIFF
--- a/documentation/docusaurus.config.ts
+++ b/documentation/docusaurus.config.ts
@@ -35,7 +35,7 @@ const config: Config = {
           routeBasePath: '/',
           
           editUrl:
-            'https://github.com/owasp-dep-scan/dep-scan/tree/master/docs',
+            'https://github.com/owasp-dep-scan/dep-scan/tree/master/documentation',
         },
         blog: {
           showReadingTime: true,


### PR DESCRIPTION
The location for docusarus edit has changed to `/documentation`. I tested this with a local docker docusarus setup; please review before merge.