### PR TITLE
Docs: fix typo in quick start docker command

### DIFF
--- a/documentation/docs/getting-started.mdx
+++ b/documentation/docs/getting-started.mdx
@@ -16,7 +16,7 @@ Run dep-scan quickly on your project and receive reports in `reports` directory.
 
 ```bash
 cd /path/to/your/project
-docker run --rm -v $PWD:/app ghcr.io/owasp-dep-scan/dep-scan --src /app --reports-dir /app/reports
+docker run --rm -v $PWD:/app ghcr.io/owasp-dep-scan/dep-scan depscan --src /app --reports-dir /app/reports
 ```
 
 :::tip


### PR DESCRIPTION
The `depscan` is missing in `docker run --rm -v $PWD:/app ghcr.io/owasp-dep-scan/dep-scan depscan --src /app --reports-dir /app/depscan`