### PR TITLE
Remove direct dependency on cdxgen

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,6 @@ dep-scan is ideal for use during continuous integration (CI) and as a local deve
 ### Scanning projects locally (Python version)
 
 ```bash
-sudo npm install -g @cyclonedx/cdxgen
 # Normal version recommended for most users (MIT)
 pip install owasp-depscan
 
@@ -106,9 +105,12 @@ pip install owasp-depscan
 pip install owasp-depscan[all]
 ```
 
-This would install two commands called `cdxgen` and `depscan`.
+This would install `depscan`.
 
-You can invoke the scan command directly with the various options.
+You can invoke the scan command directly with the various options
+
+> [!NOTE]
+> depscan requires docker to generate sbom using [cdxgen](https://github.com/cdxgen/cdxgen)
 
 ```bash
 cd <project to scan>


### PR DESCRIPTION
depscan uses docker cdxgen regardless of cdxgen being present on PATH.

```
; which cdxgen
/opt/homebrew/bin//cdxgen
; cdxgen -v
CycloneDX Generator 11.11.0
Runtime: Node.js, Version: 25.2.1

; SCAN_DEBUG_MODE=debug depscan --src $PWD --reports-dir $PWD/reports

  _|  _  ._   _  _  _. ._
 (_| (/_ |_) _> (_ (_| | |
         |

[16:46:32] DEBUG    Created a sample depscan config file at '/Users/neo/tmp/cl/aws_consoler/reports/depscan.toml.sample',
                    based on this run.
           DEBUG    Pulling the image ghcr.io/cyclonedx/cdxgen:v12.0.0 using docker.
           DEBUG    Executing 'docker pull --quiet ghcr.io/cyclonedx/cdxgen:v12.0.0'
[16:46:33] DEBUG    Cannot connect to the Docker daemon at unix:///Users/neo/.orbstack/run/docker.sock. Is the docker
                    daemon running?

```

We should either:
1. Use cdxgen from $PATH or
2. Not have requirement on cdxgen explicitly (ie implicit docker)