### PR TITLE
Change newlines processing by analysis_lib

### DIFF
--- a/packages/analysis-lib/src/analysis_lib/utils.py
+++ b/packages/analysis-lib/src/analysis_lib/utils.py
@@ -187,13 +187,11 @@ def get_description_detail(data: Descriptions | str) -> Tuple[str, str]:
     elif "." in detail:
         description = detail.split(".")[0]
     detail = (
-        detail.replace("\\n", " ")
-        .replace("\\t", " ")
-        .replace("\\r", " ")
-        .replace("\n", " ")
-        .replace("\t", " ")
-        .replace("\r", " ")
-        .replace("\\`", "")
+        detail.replace("\\n", "\n")
+        .replace("\\t", "  ")
+        .replace("\\r", "")
+        .replace("\r", "")
+        .replace("\\`", "`")
     )
     detail = bytes.decode(encodings.utf_8.encode(detail)[0], errors="replace")
     description = description.lstrip("# ")


### PR DESCRIPTION
Hello!

First of all, thank you very much for DepScan, it’s a wonderful SCA scanning tool that I have used in multiple workplaces.

Recently I have been working on a [DefectDojo](https://github.com/defectDojo/django-DefectDojo) parser for DepScan and planned to use the `detail` field in the `*.vdr.json` report as the source for the `Impact` field, which is processed as Markdown text.

However, I encountered a problem with how DepScan formats the `detail` field: it replaces all newlines with double spaces.

I ran a  `depscan --profile research --explain --debug -i juice-shop/`, using DepScan 6.1.0, and it generated a `sbom-universal.vdr.json`.

The `detail` in that report becomes a single flat line of text with no paragraph breaks, headings, bullet lists, or inline code spans, leading to a complete loss of the advisory’s original structure.

Due to that, in general, all `detail` content is rendered as a single large header (this is the detail for CVE-2022-25881):

<img width="400" height="250" alt="image" src="https://github.com/user-attachments/assets/2a21fd6a-b8ed-499a-ac02-b15c243fb079" />

I tried to work around this by replacing double spaces back with `\n`, but in many cases this is not feasible: for example, in Markdown tables (CVE-2022-23539):

<img width="400" height="250" alt="1" src="https://github.com/user-attachments/assets/5723cb12-7893-42b8-8918-2d3bf817ba0a" />

So I partially removed few `.replace()` calls from `packages/analysis-lib/src/analysis_lib/utils.py`, and now the `detail` field is created with newlines and renders correctly:

<img width="400" height="250" alt="image" src="https://github.com/user-attachments/assets/8e9ca0e8-875a-4b49-8af7-9b9d51b6684f" />

Please consider accepting my pull request if there were no specific reasons to replace newlines in the first place.

This would allow me to publish my DepScan parser for DefectDojo, which I hope will be helpful to the community.