### PR TITLE
fix(tomlparse): CLI args override hyphenated TOML keys 

### DIFF
--- a/depscan/lib/tomlparse.py
+++ b/depscan/lib/tomlparse.py
@@ -62,19 +62,36 @@ class ArgumentParser(argparse.ArgumentParser):
 
         return default_args, cmdl_args
 
-    def find_changed_args(
-        self, default_args: argparse.Namespace, sys_args: argparse.Namespace
-    ) -> List[str]:
-        """Find the arguments that have been changed from the command
-        line to replace the .toml arguments"""
-        default_dict = vars(default_args)
-        sys_dict = vars(sys_args)
-        changed_dict = []
-        for key, value in default_dict.items():
-            sys_value = sys_dict[key]
-            if sys_value != value:
-                changed_dict.append(key)
-        return changed_dict
+    def find_changed_args(self, args: Optional[List[str]] = None) -> List[str]:
+        """Find the dest names that were explicitly supplied on the command
+        line so the TOML config does not override them.
+
+        A plain value comparison against the defaults misses arguments that
+        are explicitly passed with a value equal to their default (e.g.
+        ``--level info`` when ``info`` is already the default). To detect
+        those reliably, each argument's default is temporarily replaced with a
+        unique sentinel: any dest whose parsed value is not its sentinel was
+        supplied on the command line."""
+        originals: Dict[int, Any] = {}
+        sentinels: Dict[str, object] = {}
+        for action in self._actions:
+            if action.dest is argparse.SUPPRESS:
+                continue
+            originals[id(action)] = action.default
+            sentinel = object()
+            sentinels[action.dest] = sentinel
+            action.default = sentinel
+        try:
+            parsed = super().parse_args(args)
+        finally:
+            for action in self._actions:
+                if id(action) in originals:
+                    action.default = originals[id(action)]
+        return [
+            dest
+            for dest, sentinel in sentinels.items()
+            if getattr(parsed, dest, sentinel) is not sentinel
+        ]
 
     def load_toml(self, path: str) -> MutableMapping[str, Any]:
         try:
@@ -97,7 +114,7 @@ class ArgumentParser(argparse.ArgumentParser):
         """Parse the arguments from the command line and the TOML file
         and return the updated arguments. Same functionality as the
         `argparse.ArgumentParser.parse_args` method."""
-        default_args, sys_args = self.extract_args(args, namespace)
+        _, sys_args = self.extract_args(args, namespace)
         config = sys_args.config
         # These are the default arguments options updated by the command line
         if not config or not os.path.exists(config):
@@ -106,15 +123,20 @@ class ArgumentParser(argparse.ArgumentParser):
         # If a config file is passed, update the cmdl args with the config file unless
         # the argument is already specified in the command line
         toml_data = self.load_toml(config)
-        changed_args = self.find_changed_args(default_args, sys_args)
+        changed_args = self.find_changed_args(args)
         toml_args = self.remove_nested_keys(toml_data)
 
         # Replaced unchanged command line arguments with arguments from
         # the TOML file.
         for key, value in toml_args.items():
-            if key not in changed_args:
-                setattr(sys_args, key, value)
-                # Support both hyphen and underscore representations
-                setattr(sys_args, key.replace("-", "_"), value)
+            # ``changed_args`` holds argparse dest names, which are normalized
+            # to underscores (e.g. ``risk_audit``). TOML keys may mirror the
+            # hyphenated CLI flags (e.g. ``risk-audit``), so normalize the key
+            # to the argparse dest and use it for both the precedence check and
+            # the assignment, keeping the documented precedence where
+            # command-line arguments win over the TOML config.
+            dest = key.replace("-", "_")
+            if dest not in changed_args:
+                setattr(sys_args, dest, value)
 
         return sys_args

--- a/test/test_tomlparse.py
+++ b/test/test_tomlparse.py
@@ -1,0 +1,99 @@
+"""Tests for :mod:`depscan.lib.tomlparse` CLI/TOML argument precedence."""
+
+from depscan.lib.tomlparse import ArgumentParser
+
+
+def _parse_with_config(parser, toml_text, cli_args, tmp_path):
+    """Parse ``cli_args`` with a TOML config written to ``tmp_path``."""
+    config = tmp_path / "depscan.toml"
+    config.write_text(toml_text)
+    return parser.parse_args([*cli_args, "--config", str(config)])
+
+
+def test_cli_overrides_hyphenated_toml_key(tmp_path):
+    """Command-line must win over TOML even when the TOML key is hyphenated.
+
+    ``changed_args`` holds argparse's underscore dest names, so a hyphenated
+    TOML key mirroring the CLI flag (e.g. ``risk-audit``) must be normalized
+    before the precedence check; otherwise it would override an explicit CLI
+    value. Regression test for issue #513.
+    """
+    parser = ArgumentParser()
+    parser.add_argument("--risk-audit", action="store_true")
+    args = _parse_with_config(
+        parser, "risk-audit = false\n", ["--risk-audit"], tmp_path
+    )
+    assert args.risk_audit is True
+
+
+def test_hyphenated_toml_key_fills_when_absent_on_cli(tmp_path):
+    """A hyphenated TOML key still populates the value when unset on the CLI."""
+    parser = ArgumentParser()
+    parser.add_argument("--risk-audit", action="store_true")
+    args = _parse_with_config(parser, "risk-audit = true\n", [], tmp_path)
+    assert args.risk_audit is True
+
+
+def test_underscore_toml_key_fills_when_absent_on_cli(tmp_path):
+    """Underscore TOML keys keep working unchanged."""
+    parser = ArgumentParser()
+    parser.add_argument("--foo-bar")
+    args = _parse_with_config(parser, 'foo_bar = "fromtoml"\n', [], tmp_path)
+    assert args.foo_bar == "fromtoml"
+
+
+def test_cli_overrides_hyphenated_toml_string_key(tmp_path):
+    """CLI wins for hyphenated string-valued keys as well."""
+    parser = ArgumentParser()
+    parser.add_argument("--bom-dir", default="/default")
+    args = _parse_with_config(
+        parser, 'bom-dir = "/fromtoml"\n', ["--bom-dir", "/fromcli"], tmp_path
+    )
+    assert args.bom_dir == "/fromcli"
+
+
+def test_hyphenated_toml_string_key_fills_when_absent_on_cli(tmp_path):
+    """A hyphenated string TOML key fills the value when unset on the CLI."""
+    parser = ArgumentParser()
+    parser.add_argument("--bom-dir", default="/default")
+    args = _parse_with_config(parser, 'bom-dir = "/fromtoml"\n', [], tmp_path)
+    assert args.bom_dir == "/fromtoml"
+
+
+def test_cli_wins_when_explicit_value_equals_default(tmp_path):
+    """CLI wins even when the value passed equals the argument's default.
+
+    Detecting "changed" arguments by comparing against the default value
+    misses a flag explicitly passed with its default value (e.g.
+    ``--level info`` when ``info`` is the default). The TOML value then
+    wrongly overrode the explicit CLI value. This checks the sentinel-based
+    detection treats such arguments as explicitly supplied.
+    """
+    parser = ArgumentParser()
+    parser.add_argument("--level", default="info")
+    args = _parse_with_config(
+        parser, 'level = "high"\n', ["--level", "info"], tmp_path
+    )
+    assert args.level == "info"
+
+
+def test_store_true_default_true_cli_wins(tmp_path):
+    """A store_true flag whose default is already True is still detected.
+
+    Passing the flag leaves the value at its default (True), so a value
+    comparison could not tell it apart from an unset flag. Sentinel
+    detection recognizes it as supplied and keeps the CLI value.
+    """
+    parser = ArgumentParser()
+    parser.add_argument("--deep", action="store_true", default=True)
+    args = _parse_with_config(parser, "deep = false\n", ["--deep"], tmp_path)
+    assert args.deep is True
+
+
+def test_no_hyphenated_attribute_is_set(tmp_path):
+    """TOML values are stored only under the normalized dest name."""
+    parser = ArgumentParser()
+    parser.add_argument("--bom-dir", default="/default")
+    args = _parse_with_config(parser, 'bom-dir = "/fromtoml"\n', [], tmp_path)
+    assert not hasattr(args, "bom-dir")
+    assert args.bom_dir == "/fromtoml"


### PR DESCRIPTION
Fixes #513 