### PR TITLE
fix(server): validate profile, re-check scan paths, and stage BOM temp files privately

### DIFF
--- a/.github/workflows/dockertests.yml
+++ b/.github/workflows/dockertests.yml
@@ -190,6 +190,9 @@ jobs:
           name: containertests_ubuntu-latest_python3.11
           path: containertests_ubuntu-latest_python3.11
       - name: Test container images
+        # bash is required on Windows too: the step relies on ${GITHUB_WORKSPACE},
+        # which pwsh expands to an empty string.
+        shell: bash
         run: |
           mkdir -p containertests_${{ matrix.os }}_python${{ matrix.python-version }}
           uv run depscan --no-banner --bom ${GITHUB_WORKSPACE}/containertests_ubuntu-latest_python3.11/slim/sbom-docker.cdx.json -o containertests_${{ matrix.os }}_python${{ matrix.python-version }} --no-vuln-table
@@ -212,6 +215,7 @@ jobs:
       matrix:
         os: [ macos-26, windows-latest ]
         python-version: [ '3.12' ]
+      fail-fast: false
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
@@ -240,12 +244,12 @@ jobs:
         run: |
           mkdir -p containertests_${{ matrix.os }}
           mkdir -p containertests_ubuntu-latest/microservices
-          mkdir -p containertests_ubuntu-latest/NodeGoat
+          mkdir -p containertests_ubuntu-latest/nodegoat
           mv containertests_ubuntu-latest/msd/sbom-go.cdx.json containertests_ubuntu-latest/microservices/sbom-msd-go.cdx.json
           mv containertests_ubuntu-latest/ng-reports/sbom-js.cdx.json containertests_ubuntu-latest/nodegoat/sbom-js.cdx.json
           cp contrib/csaf.toml containertests_ubuntu-latest/microservices/csaf.toml
           cp contrib/csaf.toml containertests_ubuntu-latest/nodegoat/csaf.toml
-          uv run depscan --no-banner --bom ${GITHUB_WORKSPACE}/containertests_ubuntu-latest/sbom-rocket-docker.cdx.json -o containertests_${{ matrix.os }}/reports --no-vuln-table
+          uv run depscan --no-banner --bom ${GITHUB_WORKSPACE}/containertests_ubuntu-latest/sbom-docker.cdx.json -o containertests_${{ matrix.os }}/reports --no-vuln-table
           uv run depscan --csaf --no-banner --bom ${GITHUB_WORKSPACE}/containertests_ubuntu-latest/microservices/sbom-msd-go.cdx.json --reports-dir ${GITHUB_WORKSPACE}/containertests_${{ matrix.os }}/reports
           uv run depscan --csaf --no-banner --bom ${GITHUB_WORKSPACE}/containertests_ubuntu-latest/nodegoat/sbom-js.cdx.json --reports-dir ${GITHUB_WORKSPACE}/containertests_${{ matrix.os }}/ng-reports
         env:

--- a/.github/workflows/repotests.yml
+++ b/.github/workflows/repotests.yml
@@ -29,17 +29,39 @@ jobs:
       - name: Download ukaina boms
         run: |
           mkdir -p ${GITHUB_WORKSPACE}/ukaina_boms
+          # --include takes a single pattern and must be repeated. Passing
+          # several patterns to one flag makes the CLI treat all but the first
+          # as positional filenames and silently ignore --include altogether.
+          # The repo tests generate their own VDRs, so the published ones are
+          # excluded from the artifact.
           bash ${GITHUB_WORKSPACE}/contrib/hf_download.sh AppThreat/ukaina --repo-type dataset --local-dir ${GITHUB_WORKSPACE}/ukaina_boms \
-            --include "java/Signal-Android/*.json" "java/dependency-track/*.json" "java/kafka-4.0.0-src/*.json" \
-              "js/cdxgen/*.json" "js/Signal-Desktop/*.json" "js/forgejo/*.json" \
-              "rust/biome/*.json" "rust/rustdesk/*.json" "rust/rustpad/*.json" \
-              "python/django-DefectDojo/*.json" "python/depscan/*.json" \
-              "php/phpmyadmin/*.json" \
-              "c/openssl-3.5.0/*.json" "c/open5gs-2.7.5/*.json" "c/curl-8.13.0/*.json"
-          # The repo tests scan the BOMs and generate their own VDRs, so the
-          # published ones must not be part of the artifact.
-          find ${GITHUB_WORKSPACE}/ukaina_boms -name '*.vdr.json' -delete
+            --exclude "*.vdr.json" \
+            --include "java/Signal-Android/*.json" \
+            --include "java/dependency-track/*.json" \
+            --include "java/kafka-4.0.0-src/*.json" \
+            --include "js/cdxgen/*.json" \
+            --include "js/Signal-Desktop/*.json" \
+            --include "js/forgejo/*.json" \
+            --include "rust/biome/*.json" \
+            --include "rust/rustdesk/*.json" \
+            --include "rust/rustpad/*.json" \
+            --include "python/django-DefectDojo/*.json" \
+            --include "python/depscan/*.json" \
+            --include "php/phpmyadmin/*.json" \
+            --include "c/openssl-3.5.0/*.json" \
+            --include "c/open5gs-2.7.5/*.json" \
+            --include "c/curl-8.13.0/*.json"
           rm -rf ${GITHUB_WORKSPACE}/ukaina_boms/.cache
+          # Fail loudly here rather than in a matrix job if a project is missing.
+          for project in java/Signal-Android java/dependency-track java/kafka-4.0.0-src \
+            js/cdxgen js/Signal-Desktop js/forgejo rust/biome rust/rustdesk rust/rustpad \
+            python/django-DefectDojo python/depscan php/phpmyadmin c/openssl-3.5.0 \
+            c/open5gs-2.7.5 c/curl-8.13.0; do
+            if [ -z "$(ls -A "${GITHUB_WORKSPACE}/ukaina_boms/${project}" 2>/dev/null)" ]; then
+              echo "No BOMs were downloaded for ${project}" >&2
+              exit 1
+            fi
+          done
           ls -R ${GITHUB_WORKSPACE}/ukaina_boms
         shell: bash
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1

--- a/.github/workflows/repotests.yml
+++ b/.github/workflows/repotests.yml
@@ -10,13 +10,50 @@ concurrency:
 permissions:
   contents: read
 jobs:
+  # The pre-generated BOMs used by the repo tests are fetched once here and
+  # shared with every matrix entry as an artifact. Downloading them in each job
+  # instead makes huggingface.co rate limit the run (HTTP 429), because the
+  # whole matrix asks for the same dataset at the same time.
+  ukaina-boms:
+    runs-on: ubuntu-24.04
+    env:
+      HF_TOKEN: ${{ secrets.HF_RO }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Install uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
+        with:
+          python-version: '3.12'
+      - name: Download ukaina boms
+        run: |
+          mkdir -p ${GITHUB_WORKSPACE}/ukaina_boms
+          bash ${GITHUB_WORKSPACE}/contrib/hf_download.sh AppThreat/ukaina --repo-type dataset --local-dir ${GITHUB_WORKSPACE}/ukaina_boms \
+            --include "java/Signal-Android/*.json" "java/dependency-track/*.json" "java/kafka-4.0.0-src/*.json" \
+              "js/cdxgen/*.json" "js/Signal-Desktop/*.json" "js/forgejo/*.json" \
+              "rust/biome/*.json" "rust/rustdesk/*.json" "rust/rustpad/*.json" \
+              "python/django-DefectDojo/*.json" "python/depscan/*.json" \
+              "php/phpmyadmin/*.json" \
+              "c/openssl-3.5.0/*.json" "c/open5gs-2.7.5/*.json" "c/curl-8.13.0/*.json"
+          # The repo tests scan the BOMs and generate their own VDRs, so the
+          # published ones must not be part of the artifact.
+          find ${GITHUB_WORKSPACE}/ukaina_boms -name '*.vdr.json' -delete
+          rm -rf ${GITHUB_WORKSPACE}/ukaina_boms/.cache
+          ls -R ${GITHUB_WORKSPACE}/ukaina_boms
+        shell: bash
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: ukaina-boms
+          path: ukaina_boms
+          if-no-files-found: error
   os-repo-tests:
+    needs: ukaina-boms
     env:
       VDB_DATABASE_URL: "ghcr.io/appthreat/vdbxz-app-2y:v6.7.x"
       PYTHONIOENCODING: ${{ matrix.os == 'windows-latest' && 'utf-8' || '' }}
       PYTHONUTF8: ${{ matrix.os == 'windows-latest' && '1' || '' }}
       DISABLE_CONSOLE_EMOJI: ${{ matrix.os == 'windows-latest' && '1' || '' }}
-      HF_TOKEN: ${{ secrets.HF_RO }}
     strategy:
       fail-fast: false
       matrix:
@@ -78,8 +115,12 @@ jobs:
       - name: Install depscan
         run: |
           uv sync --all-extras --all-packages --dev
-          uv pip install -U "huggingface_hub[cli]"
           npm install -g @cyclonedx/cdxgen
+      - name: Get ukaina boms
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: ukaina-boms
+          path: ukaina_boms
       - name: repotests java-sec-code
         run: |
           mkdir -p ${GITHUB_WORKSPACE}/depscan_reports/java-sec-code ${GITHUB_WORKSPACE}/depscan_reports/java-sec-code1 ${GITHUB_WORKSPACE}/depscan_reports/java-sec-code2
@@ -113,73 +154,73 @@ jobs:
           BLINTDB_HOME: ${{ runner.temp }}/blintdb-home
       - name: repotests Signal-Android
         run: |
-          mkdir -p ${GITHUB_WORKSPACE}/depscan_reports/Signal-Android
-          uv run hf download AppThreat/ukaina --include "java/Signal-Android/*.json" --exclude "java/Signal-Android/*.vdr.json" --repo-type dataset --local-dir ${GITHUB_WORKSPACE}/depscan_reports/Signal-Android
+          mkdir -p ${GITHUB_WORKSPACE}/depscan_reports/Signal-Android/java
+          cp -R ${GITHUB_WORKSPACE}/ukaina_boms/java/Signal-Android ${GITHUB_WORKSPACE}/depscan_reports/Signal-Android/java/
           uv run depscan --src ${GITHUB_WORKSPACE}/depscan_reports/Signal-Android --bom-dir ${GITHUB_WORKSPACE}/depscan_reports/Signal-Android --reports-dir ${GITHUB_WORKSPACE}/depscan_reports/Signal-Android --reachability-analyzer SemanticReachability --explain
           rm -rf ${GITHUB_WORKSPACE}/depscan_reports
         shell: bash
       - name: repotests dependency-track
         run: |
-          mkdir -p ${GITHUB_WORKSPACE}/depscan_reports/dependency-track
-          uv run hf download AppThreat/ukaina --include "java/dependency-track/*.json" --exclude "java/dependency-track/*.vdr.json" --repo-type dataset --local-dir ${GITHUB_WORKSPACE}/depscan_reports/dependency-track
+          mkdir -p ${GITHUB_WORKSPACE}/depscan_reports/dependency-track/java
+          cp -R ${GITHUB_WORKSPACE}/ukaina_boms/java/dependency-track ${GITHUB_WORKSPACE}/depscan_reports/dependency-track/java/
           uv run depscan --src ${GITHUB_WORKSPACE}/depscan_reports/dependency-track --bom-dir ${GITHUB_WORKSPACE}/depscan_reports/dependency-track --reports-dir ${GITHUB_WORKSPACE}/depscan_reports/dependency-track --reachability-analyzer SemanticReachability --explain
           uv run depscan --src ${GITHUB_WORKSPACE}/depscan_reports/dependency-track --bom-dir ${GITHUB_WORKSPACE}/depscan_reports/dependency-track --reports-dir ${GITHUB_WORKSPACE}/depscan_reports/dependency-track --reachability-analyzer SemanticReachability --explain --explanation-mode NonReachables
           rm -rf ${GITHUB_WORKSPACE}/depscan_reports
         shell: bash
       - name: repotests kafka-4.0.0-src
         run: |
-          mkdir -p ${GITHUB_WORKSPACE}/depscan_reports/kafka-4.0.0-src
-          uv run hf download AppThreat/ukaina --include "java/kafka-4.0.0-src/*.json" --exclude "java/kafka-4.0.0-src/*.vdr.json" --repo-type dataset --local-dir ${GITHUB_WORKSPACE}/depscan_reports/kafka-4.0.0-src
+          mkdir -p ${GITHUB_WORKSPACE}/depscan_reports/kafka-4.0.0-src/java
+          cp -R ${GITHUB_WORKSPACE}/ukaina_boms/java/kafka-4.0.0-src ${GITHUB_WORKSPACE}/depscan_reports/kafka-4.0.0-src/java/
           uv run depscan --src ${GITHUB_WORKSPACE}/depscan_reports/kafka-4.0.0-src --bom-dir ${GITHUB_WORKSPACE}/depscan_reports/kafka-4.0.0-src --reports-dir ${GITHUB_WORKSPACE}/depscan_reports/kafka-4.0.0-src --reachability-analyzer SemanticReachability --explain
           rm -rf ${GITHUB_WORKSPACE}/depscan_reports
         shell: bash
       - name: repotests cdxgen
         run: |
-          mkdir -p ${GITHUB_WORKSPACE}/depscan_reports/cdxgen
-          uv run hf download AppThreat/ukaina --include "js/cdxgen/*.json" --exclude "js/cdxgen/*.vdr.json" --repo-type dataset --local-dir ${GITHUB_WORKSPACE}/depscan_reports/cdxgen
+          mkdir -p ${GITHUB_WORKSPACE}/depscan_reports/cdxgen/js
+          cp -R ${GITHUB_WORKSPACE}/ukaina_boms/js/cdxgen ${GITHUB_WORKSPACE}/depscan_reports/cdxgen/js/
           uv run depscan --src ${GITHUB_WORKSPACE}/depscan_reports/cdxgen --bom-dir ${GITHUB_WORKSPACE}/depscan_reports/cdxgen --reports-dir ${GITHUB_WORKSPACE}/depscan_reports/cdxgen --reachability-analyzer SemanticReachability --explain
           uv run depscan --src ${GITHUB_WORKSPACE}/depscan_reports/cdxgen --bom-dir ${GITHUB_WORKSPACE}/depscan_reports/cdxgen --reports-dir ${GITHUB_WORKSPACE}/depscan_reports/cdxgen --reachability-analyzer SemanticReachability --explain --explanation-mode NonReachables
           rm -rf ${GITHUB_WORKSPACE}/depscan_reports
         shell: bash
       - name: repotests Signal-Desktop
         run: |
-          mkdir -p ${GITHUB_WORKSPACE}/depscan_reports/Signal-Desktop
-          uv run hf download AppThreat/ukaina --include "js/Signal-Desktop/*.json" --exclude "js/Signal-Desktop/*.vdr.json" --repo-type dataset --local-dir ${GITHUB_WORKSPACE}/depscan_reports/Signal-Desktop
+          mkdir -p ${GITHUB_WORKSPACE}/depscan_reports/Signal-Desktop/js
+          cp -R ${GITHUB_WORKSPACE}/ukaina_boms/js/Signal-Desktop ${GITHUB_WORKSPACE}/depscan_reports/Signal-Desktop/js/
           uv run depscan --src ${GITHUB_WORKSPACE}/depscan_reports/Signal-Desktop --bom-dir ${GITHUB_WORKSPACE}/depscan_reports/Signal-Desktop --reports-dir ${GITHUB_WORKSPACE}/depscan_reports/Signal-Desktop --reachability-analyzer SemanticReachability --explain
           rm -rf ${GITHUB_WORKSPACE}/depscan_reports
         shell: bash
       - name: repotests forgejo
         run: |
-          mkdir -p ${GITHUB_WORKSPACE}/depscan_reports/forgejo
-          uv run hf download AppThreat/ukaina --include "js/forgejo/*.json" --exclude "js/forgejo/*.vdr.json" --repo-type dataset --local-dir ${GITHUB_WORKSPACE}/depscan_reports/forgejo
+          mkdir -p ${GITHUB_WORKSPACE}/depscan_reports/forgejo/js
+          cp -R ${GITHUB_WORKSPACE}/ukaina_boms/js/forgejo ${GITHUB_WORKSPACE}/depscan_reports/forgejo/js/
           uv run depscan --src ${GITHUB_WORKSPACE}/depscan_reports/forgejo --bom-dir ${GITHUB_WORKSPACE}/depscan_reports/forgejo --reports-dir ${GITHUB_WORKSPACE}/depscan_reports/forgejo --reachability-analyzer SemanticReachability --explain
           rm -rf ${GITHUB_WORKSPACE}/depscan_reports
         shell: bash
       - name: repotests biome
         run: |
-          mkdir -p ${GITHUB_WORKSPACE}/depscan_reports/biome
-          uv run hf download AppThreat/ukaina --include "rust/biome/*.json" --exclude "rust/biome/*.vdr.json" --repo-type dataset --local-dir ${GITHUB_WORKSPACE}/depscan_reports/biome
+          mkdir -p ${GITHUB_WORKSPACE}/depscan_reports/biome/rust
+          cp -R ${GITHUB_WORKSPACE}/ukaina_boms/rust/biome ${GITHUB_WORKSPACE}/depscan_reports/biome/rust/
           uv run depscan --src ${GITHUB_WORKSPACE}/depscan_reports/biome --bom-dir ${GITHUB_WORKSPACE}/depscan_reports/biome --reports-dir ${GITHUB_WORKSPACE}/depscan_reports/biome --reachability-analyzer SemanticReachability --explain
           rm -rf ${GITHUB_WORKSPACE}/depscan_reports
         shell: bash
       - name: repotests rustdesk
         run: |
-          mkdir -p ${GITHUB_WORKSPACE}/depscan_reports/rustdesk
-          uv run hf download AppThreat/ukaina --include "rust/rustdesk/*.json" --exclude "rust/rustdesk/*.vdr.json" --repo-type dataset --local-dir ${GITHUB_WORKSPACE}/depscan_reports/rustdesk
+          mkdir -p ${GITHUB_WORKSPACE}/depscan_reports/rustdesk/rust
+          cp -R ${GITHUB_WORKSPACE}/ukaina_boms/rust/rustdesk ${GITHUB_WORKSPACE}/depscan_reports/rustdesk/rust/
           uv run depscan --src ${GITHUB_WORKSPACE}/depscan_reports/rustdesk --bom-dir ${GITHUB_WORKSPACE}/depscan_reports/rustdesk --reports-dir ${GITHUB_WORKSPACE}/depscan_reports/rustdesk --reachability-analyzer SemanticReachability --explain
           rm -rf ${GITHUB_WORKSPACE}/depscan_reports
         shell: bash
       - name: repotests rustpad
         run: |
-          mkdir -p ${GITHUB_WORKSPACE}/depscan_reports/rustpad
-          uv run hf download AppThreat/ukaina --include "rust/rustpad/*.json" --exclude "rust/rustpad/*.vdr.json" --repo-type dataset --local-dir ${GITHUB_WORKSPACE}/depscan_reports/rustpad
+          mkdir -p ${GITHUB_WORKSPACE}/depscan_reports/rustpad/rust
+          cp -R ${GITHUB_WORKSPACE}/ukaina_boms/rust/rustpad ${GITHUB_WORKSPACE}/depscan_reports/rustpad/rust/
           uv run depscan --src ${GITHUB_WORKSPACE}/depscan_reports/rustpad --bom-dir ${GITHUB_WORKSPACE}/depscan_reports/rustpad --reports-dir ${GITHUB_WORKSPACE}/depscan_reports/rustpad --reachability-analyzer SemanticReachability --explain
           rm -rf ${GITHUB_WORKSPACE}/depscan_reports
         shell: bash
       - name: repotests django-DefectDojo
         run: |
-          mkdir -p ${GITHUB_WORKSPACE}/depscan_reports/django-DefectDojo
-          uv run hf download AppThreat/ukaina --include "python/django-DefectDojo/*.json" --exclude "python/django-DefectDojo/*.vdr.json" --repo-type dataset --local-dir ${GITHUB_WORKSPACE}/depscan_reports/django-DefectDojo
+          mkdir -p ${GITHUB_WORKSPACE}/depscan_reports/django-DefectDojo/python
+          cp -R ${GITHUB_WORKSPACE}/ukaina_boms/python/django-DefectDojo ${GITHUB_WORKSPACE}/depscan_reports/django-DefectDojo/python/
           uv run depscan --src ${GITHUB_WORKSPACE}/depscan_reports/django-DefectDojo --bom-dir ${GITHUB_WORKSPACE}/depscan_reports/django-DefectDojo --reports-dir ${GITHUB_WORKSPACE}/depscan_reports/django-DefectDojo --reachability-analyzer SemanticReachability --explain
           uv run depscan --src ${GITHUB_WORKSPACE}/depscan_reports/django-DefectDojo --bom-dir ${GITHUB_WORKSPACE}/depscan_reports/django-DefectDojo --reports-dir ${GITHUB_WORKSPACE}/depscan_reports/django-DefectDojo --reachability-analyzer SemanticReachability --explain --explanation-mode Endpoints
           uv run depscan --src ${GITHUB_WORKSPACE}/depscan_reports/django-DefectDojo --bom-dir ${GITHUB_WORKSPACE}/depscan_reports/django-DefectDojo --reports-dir ${GITHUB_WORKSPACE}/depscan_reports/django-DefectDojo --reachability-analyzer SemanticReachability --explain --explanation-mode NonReachables
@@ -187,37 +228,37 @@ jobs:
         shell: bash
       - name: repotests depscan
         run: |
-          mkdir -p ${GITHUB_WORKSPACE}/depscan_reports/depscan
-          uv run hf download AppThreat/ukaina --include "python/depscan/*.json" --exclude "python/depscan/*.vdr.json" --repo-type dataset --local-dir ${GITHUB_WORKSPACE}/depscan_reports/depscan
+          mkdir -p ${GITHUB_WORKSPACE}/depscan_reports/depscan/python
+          cp -R ${GITHUB_WORKSPACE}/ukaina_boms/python/depscan ${GITHUB_WORKSPACE}/depscan_reports/depscan/python/
           uv run depscan --src ${GITHUB_WORKSPACE}/depscan_reports/depscan --bom-dir ${GITHUB_WORKSPACE}/depscan_reports/depscan --reports-dir ${GITHUB_WORKSPACE}/depscan_reports/depscan --reachability-analyzer SemanticReachability --explain
           uv run depscan --src ${GITHUB_WORKSPACE}/depscan_reports/depscan --bom-dir ${GITHUB_WORKSPACE}/depscan_reports/depscan --reports-dir ${GITHUB_WORKSPACE}/depscan_reports/depscan --reachability-analyzer SemanticReachability --explain --explanation-mode Endpoints
           rm -rf ${GITHUB_WORKSPACE}/depscan_reports
         shell: bash
       - name: repotests phpmyadmin
         run: |
-          mkdir -p ${GITHUB_WORKSPACE}/depscan_reports/phpmyadmin
-          uv run hf download AppThreat/ukaina --include "php/phpmyadmin/*.json" --exclude "php/phpmyadmin/*.vdr.json" --repo-type dataset --local-dir ${GITHUB_WORKSPACE}/depscan_reports/phpmyadmin
+          mkdir -p ${GITHUB_WORKSPACE}/depscan_reports/phpmyadmin/php
+          cp -R ${GITHUB_WORKSPACE}/ukaina_boms/php/phpmyadmin ${GITHUB_WORKSPACE}/depscan_reports/phpmyadmin/php/
           uv run depscan --src ${GITHUB_WORKSPACE}/depscan_reports/phpmyadmin --bom-dir ${GITHUB_WORKSPACE}/depscan_reports/phpmyadmin --reports-dir ${GITHUB_WORKSPACE}/depscan_reports/phpmyadmin --reachability-analyzer SemanticReachability --explain
           rm -rf ${GITHUB_WORKSPACE}/depscan_reports
         shell: bash
       - name: repotests openssl-3.5.0
         run: |
-          mkdir -p ${GITHUB_WORKSPACE}/depscan_reports/openssl-3.5.0
-          uv run hf download AppThreat/ukaina --include "c/openssl-3.5.0/*.json" --exclude "c/openssl-3.5.0/*.vdr.json" --repo-type dataset --local-dir ${GITHUB_WORKSPACE}/depscan_reports/openssl-3.5.0
+          mkdir -p ${GITHUB_WORKSPACE}/depscan_reports/openssl-3.5.0/c
+          cp -R ${GITHUB_WORKSPACE}/ukaina_boms/c/openssl-3.5.0 ${GITHUB_WORKSPACE}/depscan_reports/openssl-3.5.0/c/
           uv run depscan --src ${GITHUB_WORKSPACE}/depscan_reports/openssl-3.5.0 --bom-dir ${GITHUB_WORKSPACE}/depscan_reports/openssl-3.5.0 --reports-dir ${GITHUB_WORKSPACE}/depscan_reports/openssl-3.5.0 --reachability-analyzer SemanticReachability --explain
           rm -rf ${GITHUB_WORKSPACE}/depscan_reports
         shell: bash
       - name: repotests open5gs-2.7.5
         run: |
-          mkdir -p ${GITHUB_WORKSPACE}/depscan_reports/open5gs-2.7.5
-          uv run hf download AppThreat/ukaina --include "c/open5gs-2.7.5/*.json" --exclude "c/open5gs-2.7.5/*.vdr.json" --repo-type dataset --local-dir ${GITHUB_WORKSPACE}/depscan_reports/open5gs-2.7.5
+          mkdir -p ${GITHUB_WORKSPACE}/depscan_reports/open5gs-2.7.5/c
+          cp -R ${GITHUB_WORKSPACE}/ukaina_boms/c/open5gs-2.7.5 ${GITHUB_WORKSPACE}/depscan_reports/open5gs-2.7.5/c/
           uv run depscan --src ${GITHUB_WORKSPACE}/depscan_reports/open5gs-2.7.5 --bom-dir ${GITHUB_WORKSPACE}/depscan_reports/open5gs-2.7.5 --reports-dir ${GITHUB_WORKSPACE}/depscan_reports/open5gs-2.7.5 --reachability-analyzer SemanticReachability --explain
           rm -rf ${GITHUB_WORKSPACE}/depscan_reports
         shell: bash
       - name: repotests curl-8.13.0
         run: |
-          mkdir -p ${GITHUB_WORKSPACE}/depscan_reports/curl-8.13.0
-          uv run hf download AppThreat/ukaina --include "c/curl-8.13.0/*.json" --exclude "c/curl-8.13.0/*.vdr.json" --repo-type dataset --local-dir ${GITHUB_WORKSPACE}/depscan_reports/curl-8.13.0
+          mkdir -p ${GITHUB_WORKSPACE}/depscan_reports/curl-8.13.0/c
+          cp -R ${GITHUB_WORKSPACE}/ukaina_boms/c/curl-8.13.0 ${GITHUB_WORKSPACE}/depscan_reports/curl-8.13.0/c/
           uv run depscan --src ${GITHUB_WORKSPACE}/depscan_reports/curl-8.13.0 --bom-dir ${GITHUB_WORKSPACE}/depscan_reports/curl-8.13.0 --reports-dir ${GITHUB_WORKSPACE}/depscan_reports/curl-8.13.0 --reachability-analyzer SemanticReachability --explain --explanation-mode NonReachables
           rm -rf ${GITHUB_WORKSPACE}/depscan_reports
         shell: bash

--- a/contrib/hf_download.sh
+++ b/contrib/hf_download.sh
@@ -18,7 +18,7 @@ attempts="${HF_DOWNLOAD_ATTEMPTS:-5}"
 delay="${HF_DOWNLOAD_DELAY:-15}"
 
 for attempt in $(seq 1 "${attempts}"); do
-  if uvx --from "huggingface_hub[cli]" hf download "$@"; then
+  if uvx --from huggingface_hub hf download "$@"; then
     exit 0
   fi
   if [ "${attempt}" -eq "${attempts}" ]; then

--- a/contrib/hf_download.sh
+++ b/contrib/hf_download.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Wrapper around `hf download` that retries with exponential backoff.
+#
+# The repo tests pull pre-generated BOMs from the AppThreat/ukaina dataset in
+# every matrix job. huggingface.co answers a share of those requests with
+# HTTP 429 (Too Many Requests) even with HF_TOKEN set, simply because the whole
+# matrix fetches the same dataset at the same time. A single attempt is
+# therefore not reliable enough to gate a build on.
+#
+# The CLI runs through uvx so the download does not depend on the project
+# virtual environment.
+#
+# Usage: hf_download.sh <hf download arguments...>
+# Tunables: HF_DOWNLOAD_ATTEMPTS (default 5), HF_DOWNLOAD_DELAY (default 15s).
+set -uo pipefail
+
+attempts="${HF_DOWNLOAD_ATTEMPTS:-5}"
+delay="${HF_DOWNLOAD_DELAY:-15}"
+
+for attempt in $(seq 1 "${attempts}"); do
+  if uvx --from "huggingface_hub[cli]" hf download "$@"; then
+    exit 0
+  fi
+  if [ "${attempt}" -eq "${attempts}" ]; then
+    break
+  fi
+  echo "hf download failed (attempt ${attempt}/${attempts}); retrying in ${delay}s" >&2
+  sleep "${delay}"
+  delay=$((delay * 2))
+done
+
+echo "hf download failed after ${attempts} attempts: $*" >&2
+exit 1

--- a/depscan/cli_options.py
+++ b/depscan/cli_options.py
@@ -1,5 +1,8 @@
 import argparse
 import os
+
+from analysis_lib.config import SUPPORTED_BOM_PROFILES
+
 from depscan import get_version
 from depscan.lib import tomlparse
 
@@ -75,19 +78,7 @@ def build_parser():
     parser.add_argument(
         "--profile",
         default="generic",
-        choices=(
-            "appsec",
-            "research",
-            "operational",
-            "threat-modeling",
-            "license-compliance",
-            "generic",
-            "machine-learning",
-            "ml",
-            "deep-learning",
-            "ml-deep",
-            "ml-tiny",
-        ),
+        choices=SUPPORTED_BOM_PROFILES,
         dest="profile",
         help="Profile to use while generating the BOM. For granular control, use the arguments --bom-engine, --vulnerability-analyzer, or --reachability-analyzer.",
     )

--- a/packages/analysis-lib/src/analysis_lib/config.py
+++ b/packages/analysis-lib/src/analysis_lib/config.py
@@ -22,6 +22,24 @@ def get_int_from_env(name, default):
     return value
 
 
+# BOM generation profiles understood by cdxgen. This is the single source of
+# truth shared by the CLI (`--profile`) and the server (`/scan?profile=`): the
+# value is forwarded to cdxgen as a command line argument, so any caller
+# supplying it must constrain it to this set.
+SUPPORTED_BOM_PROFILES = (
+    "appsec",
+    "research",
+    "operational",
+    "threat-modeling",
+    "license-compliance",
+    "generic",
+    "machine-learning",
+    "ml",
+    "deep-learning",
+    "ml-deep",
+    "ml-tiny",
+)
+
 # CPE Full Regex including unused parameters
 CPE_FULL_REGEX = re.compile(
     "cpe:?:[^:]+:(?P<cve_type>[^:]+):(?P<vendor>[^:]+):(?P<package>[^:]+):(?P<version>[^:]+):(?P<update>[^:]+):(?P<edition>[^:]+):(?P<lang>[^:]+):(?P<sw_edition>[^:]+):(?P<target_sw>[^:]+):(?P<target_hw>[^:]+):(?P<other>[^:]+)"

--- a/packages/server-lib/src/server_lib/simple.py
+++ b/packages/server-lib/src/server_lib/simple.py
@@ -8,6 +8,7 @@ from hmac import compare_digest
 from urllib.parse import urlparse
 
 from analysis_lib import VdrAnalysisKV
+from analysis_lib.config import SUPPORTED_BOM_PROFILES
 from analysis_lib.search import get_pkgs_by_scope
 from analysis_lib.utils import get_pkg_list
 from analysis_lib.vdr import VDRAnalyzer
@@ -47,6 +48,8 @@ MAX_PROJECT_TYPE_LENGTH = 64
 DEFAULT_MAX_BOM_FILE_SIZE = 100 * 1024 * 1024
 
 UPLOAD_SIZE_LIMIT_MESSAGE = "BOM file exceeds the configured size limit."
+PATH_NOT_ALLOWED_MESSAGE = "Path not allowed"
+SERVER_TEMP_DIR_PREFIX = "depscan-server-"
 
 
 def _is_truthy(value):
@@ -87,6 +90,59 @@ def _is_allowed_scan_path(path: str, allowed_paths: list[str]) -> bool:
         except (OSError, ValueError):
             continue
     return False
+
+
+def _is_path_within(path: str, parent_dir: str) -> bool:
+    """
+    Check whether ``path`` resolves to a location inside ``parent_dir``.
+
+    Both operands are fully resolved first so symlinks and relative segments
+    cannot be used to escape the parent directory.
+    """
+    try:
+        real_path = os.path.realpath(path)
+        real_parent = os.path.realpath(parent_dir)
+    except (OSError, ValueError):
+        return False
+    try:
+        return os.path.commonpath((real_path, real_parent)) == real_parent
+    except (OSError, ValueError):
+        return False
+
+
+def _revalidate_scan_path(path: str | None) -> bool:
+    """
+    Re-check a scan path against the configured allowlist at the point of use.
+
+    ``enforce_allowlists`` validates the requested path before the request is
+    dispatched, but the path is consumed later, once BOM generation is under
+    way. Re-resolving it immediately before every filesystem access keeps a
+    symlink that appears inside an allowed directory after the initial check
+    from redirecting the scan outside the allowlist.
+    """
+    allowed_paths = app.config.get("ALLOWED_PATHS")
+    if allowed_paths is None or not path:
+        return True
+    return _is_allowed_scan_path(path, allowed_paths)
+
+
+def _get_server_temp_dir() -> str:
+    """
+    Return the private directory used for this server's temporary BOM files.
+
+    The directory is created once per process with ``0o700`` permissions so
+    uploaded and generated BOMs are not exposed to other users or to sibling
+    containers that happen to share the system temporary directory.
+    """
+    temp_dir = app.config.get("SERVER_TEMP_DIR")
+    if temp_dir and os.path.isdir(temp_dir):
+        return temp_dir
+    temp_dir = tempfile.mkdtemp(
+        prefix=SERVER_TEMP_DIR_PREFIX, dir=os.getenv("DEPSCAN_TEMP_DIR") or None
+    )
+    os.chmod(temp_dir, 0o700)
+    app.config["SERVER_TEMP_DIR"] = temp_dir
+    return temp_dir
 
 
 def _get_config_int(config, *keys: str, default: int, logger=None) -> int:
@@ -138,6 +194,10 @@ def _validate_remote_url(url: str, allowed_schemes: set[str], allow_private_urls
         return False, "URL scheme is not allowed."
     if not parsed.hostname:
         return False, "URL host is required."
+    # Credentials embedded in a scan URL would be handed to the BOM generator
+    # and, on a redirect, to whichever host it ends up talking to.
+    if parsed.username or parsed.password:
+        return False, "URL must not contain embedded credentials."
     if not allow_private_urls and _is_private_target(parsed.hostname):
         return False, "URL host resolves to a private, loopback, or otherwise restricted address."
     return True, ""
@@ -257,7 +317,7 @@ async def enforce_allowlists():
                 if not _is_allowed_scan_path(path, allowed_paths):
                     if logger_instance:
                         logger_instance.warning(f"Blocked request for path: {path}")
-                    return {"error": "true", "message": "Path not allowed"}, 403
+                    return {"error": "true", "message": PATH_NOT_ALLOWED_MESSAGE}, 403
 
 
 @app.after_request
@@ -301,6 +361,7 @@ async def run_scan():
     suggest_mode = _is_truthy(q.get("suggest"))
     fuzzy_search = _is_truthy(q.get("fuzzy_search"))
     temp_paths = []
+    path_is_caller_supplied = True
     if q.get("url"):
         url = q.get("url")
     if q.get("path"):
@@ -337,6 +398,13 @@ async def run_scan():
         project_type_list = _parse_project_types(project_type)
     except ValueError as exc:
         return {"error": "true", "message": str(exc)}, 400
+    # The profile is forwarded to cdxgen as a command line argument, so only
+    # the documented values are accepted here.
+    if profile not in SUPPORTED_BOM_PROFILES:
+        return {
+            "error": "true",
+            "message": f"profile must be one of {', '.join(SUPPORTED_BOM_PROFILES)}.",
+        }, 400
     cdxgen_server = app.config.get("CDXGEN_SERVER_URL")
     bom_file_path = None
     if uploaded_bom_file.get("file", None) is not None:
@@ -393,8 +461,15 @@ async def run_scan():
             )
         if logger_instance:
             logger_instance.debug("Processing uploaded file")
-        tmp_bom_file = tempfile.NamedTemporaryFile(delete=False, suffix=f".bom.{bom_file_suffix}")
+        tmp_bom_file = tempfile.NamedTemporaryFile(
+            delete=False,
+            suffix=f".bom.{bom_file_suffix}",
+            dir=_get_server_temp_dir(),
+        )
         path = tmp_bom_file.name
+        # The uploaded BOM now lives in the server's own temporary directory,
+        # so it is no longer a caller supplied path for allowlist purposes.
+        path_is_caller_supplied = False
         tmp_bom_file.close()
         temp_paths.append(path)
         file_write(path, bom_file_content)
@@ -407,6 +482,10 @@ async def run_scan():
     # Path points to a project directory
     # Bug# 233. Path could be a url
     try:
+        if path_is_caller_supplied and not _revalidate_scan_path(path):
+            if logger_instance:
+                logger_instance.warning("Blocked request for path: %s", path)
+            return {"error": "true", "message": PATH_NOT_ALLOWED_MESSAGE}, 403
         if url or (path and os.path.isdir(path)):
             if url and not path and not cdxgen_server:
                 return (
@@ -417,7 +496,10 @@ async def run_scan():
                     400,
                     {"Content-Type": "application/json"},
                 )
-            with tempfile.NamedTemporaryFile(delete=False, suffix=".bom.json") as bfp:
+            server_temp_dir = _get_server_temp_dir()
+            with tempfile.NamedTemporaryFile(
+                delete=False, suffix=".bom.json", dir=server_temp_dir
+            ) as bfp:
                 temp_paths.append(bfp.name)
                 if create_bom:
                     bom_status = create_bom(
@@ -437,6 +519,25 @@ async def run_scan():
                     # above always exists, so `os.path.exists` proves nothing
                     # here and only the returned path is trustworthy.
                     if bom_status.success and bom_status.primary:
+                        # Generators are expected to write inside the temporary
+                        # directory created for this request. Refusing anything
+                        # else keeps the response from returning the contents of
+                        # an unrelated file.
+                        if not _is_path_within(bom_status.primary, server_temp_dir):
+                            if logger_instance:
+                                logger_instance.warning(
+                                    "Discarding BOM written outside the server temporary "
+                                    "directory: %s",
+                                    bom_status.primary,
+                                )
+                            return (
+                                {
+                                    "error": "true",
+                                    "message": "Generated BOM was written to an unexpected location.",
+                                },
+                                500,
+                                {"Content-Type": "application/json"},
+                            )
                         if logger_instance:
                             logger_instance.debug(
                                 "BOM file was generated successfully at %s", bom_status.primary
@@ -449,6 +550,11 @@ async def run_scan():
             bom_file_path = path
         # Direct purl-based lookups are not supported yet.
         if bom_file_path is not None:
+            # Final check before the BOM is opened and its contents returned.
+            if path_is_caller_supplied and not _revalidate_scan_path(bom_file_path):
+                if logger_instance:
+                    logger_instance.warning("Blocked request for path: %s", bom_file_path)
+                return {"error": "true", "message": PATH_NOT_ALLOWED_MESSAGE}, 403
             pkg_list, _ = get_pkg_list(bom_file_path)
             if not pkg_list:
                 if logger_instance:

--- a/packages/server-lib/tests/test_simple.py
+++ b/packages/server-lib/tests/test_simple.py
@@ -500,6 +500,292 @@ async def test_scan_attaches_vulnerabilities_to_response(
     assert data["vulnerabilities"] == sample_vulns
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("profile", ["--output", "generic; rm -rf /", "unknown-profile", ""])
+async def test_scan_rejects_unsupported_profile(client: QuartClient, tmp_path, profile):
+    """The profile reaches cdxgen as a command line argument, so only the
+    documented values may be accepted from a request."""
+    bom_path = tmp_path / "sample.bom.json"
+    _write_bom_with_components(bom_path)
+
+    response = await client.post(
+        "/scan",
+        json={"type": "js", "path": str(bom_path), "profile": profile},
+        headers={"X-Test-Remote-Addr": "127.0.0.1"},
+    )
+    if profile == "":
+        # An empty profile is ignored and the default is used.
+        assert response.status_code != 400
+        return
+    assert response.status_code == 400
+    data = await response.get_json()
+    assert "profile must be one of" in data["message"]
+
+
+@pytest.mark.asyncio
+async def test_scan_accepts_supported_profile(client: QuartClient, tmp_path, monkeypatch):
+    bom_path = tmp_path / "sample.bom.json"
+    _write_bom_with_components(bom_path)
+    captured = {}
+
+    class CapturingAnalyzer:
+        def __init__(self, vdr_options):
+            captured["options"] = vdr_options
+
+        def process(self):
+            return type("DummyResult", (), {"success": True, "pkg_vulnerabilities": []})()
+
+    monkeypatch.setattr("server_lib.simple.VDRAnalyzer", CapturingAnalyzer)
+
+    response = await client.get(
+        f"/scan?type=js&path={bom_path}&profile=appsec",
+        headers={"X-Test-Remote-Addr": "127.0.0.1"},
+    )
+    assert response.status_code == 200
+    assert captured["options"] is not None
+
+
+@pytest.mark.asyncio
+async def test_scan_query_profile_is_validated(client: QuartClient, tmp_path):
+    bom_path = tmp_path / "sample.bom.json"
+    _write_bom_with_components(bom_path)
+    response = await client.get(
+        f"/scan?type=js&path={bom_path}&profile=--deep",
+        headers={"X-Test-Remote-Addr": "127.0.0.1"},
+    )
+    assert response.status_code == 400
+    data = await response.get_json()
+    assert "profile must be one of" in data["message"]
+
+
+@pytest.mark.asyncio
+async def test_url_with_embedded_credentials_is_rejected(client: QuartClient):
+    response = await client.post(
+        "/scan",
+        json={"type": "js", "url": "https://user:token@example.com/repo.git"},
+        headers={"X-Test-Remote-Addr": "127.0.0.1"},
+    )
+    assert response.status_code == 400
+    data = await response.get_json()
+    assert "embedded credentials" in data["message"]
+
+
+def test_validate_remote_url_accepts_plain_public_url():
+    is_valid, message = simple_module._validate_remote_url(
+        "https://github.com/owasp-dep-scan/dep-scan.git",
+        simple_module.allowed_git_schemes,
+        False,
+    )
+    assert is_valid
+    assert message == ""
+
+
+@pytest.mark.asyncio
+async def test_scan_path_is_revalidated_after_dispatch(client: QuartClient, tmp_path, monkeypatch):
+    """A path that passes the initial allowlist check must be checked again
+    before it is read, so a symlink planted inside an allowed directory in the
+    meantime cannot redirect the scan."""
+    safe_dir = tmp_path / "safe"
+    safe_dir.mkdir()
+    secret = tmp_path / "secret.bom.json"
+    secret.write_text(
+        json.dumps({"bomFormat": "CycloneDX", "specVersion": "1.5"}), encoding="utf-8"
+    )
+    bom_link = safe_dir / "sample.bom.json"
+    bom_link.write_text(json.dumps({"bomFormat": "CycloneDX", "specVersion": "1.5"}), "utf-8")
+
+    app.config["ALLOWED_PATHS"] = [str(safe_dir)]
+
+    original_is_allowed = simple_module._is_allowed_scan_path
+    calls = {"count": 0}
+
+    def swap_after_first_check(path, allowed_paths):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            return original_is_allowed(path, allowed_paths)
+        # Simulate the path now resolving outside the allowed tree.
+        bom_link.unlink()
+        bom_link.symlink_to(secret)
+        return original_is_allowed(path, allowed_paths)
+
+    monkeypatch.setattr(simple_module, "_is_allowed_scan_path", swap_after_first_check)
+
+    response = await client.get(
+        f"/scan?type=js&path={bom_link}",
+        headers={"X-Test-Remote-Addr": "127.0.0.1"},
+    )
+    assert response.status_code == 403
+    data = await response.get_json()
+    assert "Path not allowed" in data["message"]
+    assert calls["count"] > 1
+
+
+@pytest.mark.asyncio
+async def test_uploaded_bom_is_not_blocked_by_path_allowlist(
+    client: QuartClient, tmp_path, monkeypatch
+):
+    """An upload is staged in the server's own temporary directory, so the
+    allowlist configured for caller supplied paths must not reject it."""
+    safe_dir = tmp_path / "safe"
+    safe_dir.mkdir()
+    app.config["ALLOWED_PATHS"] = [str(safe_dir)]
+
+    class DummyAnalyzer:
+        def __init__(self, vdr_options):
+            self.vdr_options = vdr_options
+
+        def process(self):
+            return type("DummyResult", (), {"success": True, "pkg_vulnerabilities": []})()
+
+    monkeypatch.setattr("server_lib.simple.VDRAnalyzer", DummyAnalyzer)
+
+    payload = json.dumps(
+        {"bomFormat": "CycloneDX", "specVersion": "1.5", "version": 1, "components": []}
+    ).encode("utf-8")
+    response = await client.post(
+        "/scan?type=js",
+        files={
+            "file": FileStorage(
+                stream=io.BytesIO(payload),
+                filename="sample.bom.json",
+                content_type="application/json",
+            )
+        },
+        headers={"X-Test-Remote-Addr": "127.0.0.1"},
+    )
+    assert response.status_code == 200
+    data = await response.get_json()
+    assert data["bomFormat"] == "CycloneDX"
+
+
+def test_server_temp_dir_is_private_and_reused():
+    app.config.pop("SERVER_TEMP_DIR", None)
+    temp_dir = simple_module._get_server_temp_dir()
+    try:
+        assert os.path.isdir(temp_dir)
+        assert os.path.basename(temp_dir).startswith(simple_module.SERVER_TEMP_DIR_PREFIX)
+        assert oct(os.stat(temp_dir).st_mode & 0o777) == oct(0o700)
+        assert simple_module._get_server_temp_dir() == temp_dir
+    finally:
+        app.config.pop("SERVER_TEMP_DIR", None)
+        os.rmdir(temp_dir)
+
+
+@pytest.mark.asyncio
+async def test_uploaded_bom_is_staged_in_private_temp_dir(client: QuartClient, monkeypatch):
+    staged_paths = []
+    original_file_write = simple_module.file_write
+
+    def tracking_file_write(path, content, *args, **kwargs):
+        staged_paths.append(path)
+        return original_file_write(path, content, *args, **kwargs)
+
+    monkeypatch.setattr(simple_module, "file_write", tracking_file_write)
+
+    class DummyAnalyzer:
+        def __init__(self, vdr_options):
+            self.vdr_options = vdr_options
+
+        def process(self):
+            return type("DummyResult", (), {"success": True, "pkg_vulnerabilities": []})()
+
+    monkeypatch.setattr("server_lib.simple.VDRAnalyzer", DummyAnalyzer)
+
+    payload = json.dumps(
+        {"bomFormat": "CycloneDX", "specVersion": "1.5", "version": 1, "components": []}
+    ).encode("utf-8")
+    response = await client.post(
+        "/scan?type=js",
+        files={
+            "file": FileStorage(
+                stream=io.BytesIO(payload),
+                filename="sample.bom.json",
+                content_type="application/json",
+            )
+        },
+        headers={"X-Test-Remote-Addr": "127.0.0.1"},
+    )
+    assert response.status_code == 200
+    assert staged_paths
+    assert os.path.dirname(staged_paths[0]) == simple_module._get_server_temp_dir()
+
+
+@pytest.mark.asyncio
+async def test_generated_bom_outside_temp_dir_is_rejected(client: QuartClient, tmp_path):
+    """Only a BOM written inside the directory created for the request may be
+    read back and returned to the caller."""
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    stray_bom = tmp_path / "stray.bom.json"
+    stray_bom.write_text(
+        json.dumps({"bomFormat": "CycloneDX", "specVersion": "1.5"}), encoding="utf-8"
+    )
+
+    def create_bom(bom_file, _source_dir, _options):
+        return type("BOMStatus", (), {"success": True, "primary": str(stray_bom)})()
+
+    app.config["create_bom"] = create_bom
+
+    response = await client.get(
+        f"/scan?type=js&path={project_dir}",
+        headers={"X-Test-Remote-Addr": "127.0.0.1"},
+    )
+    assert response.status_code == 500
+    data = await response.get_json()
+    assert "unexpected location" in data["message"]
+
+
+@pytest.mark.asyncio
+async def test_generated_bom_inside_temp_dir_is_accepted(
+    client: QuartClient, tmp_path, monkeypatch
+):
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+
+    def create_bom(bom_file, _source_dir, _options):
+        with open(bom_file, "w", encoding="utf-8") as fp:
+            json.dump({"bomFormat": "CycloneDX", "specVersion": "1.5", "components": []}, fp)
+        return type("BOMStatus", (), {"success": True, "primary": bom_file})()
+
+    class DummyAnalyzer:
+        def __init__(self, vdr_options):
+            self.vdr_options = vdr_options
+
+        def process(self):
+            return type("DummyResult", (), {"success": True, "pkg_vulnerabilities": []})()
+
+    app.config["create_bom"] = create_bom
+    monkeypatch.setattr("server_lib.simple.VDRAnalyzer", DummyAnalyzer)
+
+    response = await client.get(
+        f"/scan?type=js&path={project_dir}",
+        headers={"X-Test-Remote-Addr": "127.0.0.1"},
+    )
+    assert response.status_code == 200
+    data = await response.get_json()
+    assert data["bomFormat"] == "CycloneDX"
+
+
+def test_is_path_within_resolves_symlinks(tmp_path):
+    parent = tmp_path / "parent"
+    parent.mkdir()
+    outside = tmp_path / "outside.txt"
+    outside.write_text("data", encoding="utf-8")
+    inside = parent / "inside.txt"
+    inside.write_text("data", encoding="utf-8")
+    escaping_link = parent / "escape.txt"
+    escaping_link.symlink_to(outside)
+
+    assert simple_module._is_path_within(str(inside), str(parent))
+    assert not simple_module._is_path_within(str(escaping_link), str(parent))
+    assert not simple_module._is_path_within(str(outside), str(parent))
+
+
+def test_revalidate_scan_path_is_a_noop_without_allowlist():
+    app.config.pop("ALLOWED_PATHS", None)
+    assert simple_module._revalidate_scan_path("/etc/passwd")
+
+
 def test_run_server_refuses_non_local_bind_without_auth(monkeypatch):
     called = {"run": False}
 


### PR DESCRIPTION
The /scan endpoint accepted an arbitrary profile string from the query or JSON body and forwarded it to cdxgen as a command line argument, letting a caller inject cdxgen flags. The profile choices are now a shared constant in analysis_lib.config, used by both --profile and the server, and requests carrying anything else are rejected with a 400.

Scan paths are also re-validated against the allowlist immediately before the BOM is opened rather than only during request dispatch, generated BOMs are accepted only when written inside the temporary directory created for the request, temporary BOM files now live in a private 0700 directory instead of the system temporary directory, and scan URLs carrying embedded credentials are refused.